### PR TITLE
Reload log levels panel 500ms after rec update, Fixes: #184

### DIFF
--- a/admin/tabs/logging/LogLevelPanel.js
+++ b/admin/tabs/logging/LogLevelPanel.js
@@ -16,6 +16,7 @@ export class LogLevelPanel extends Component {
 
     store = new RestStore({
         url: 'rest/logLevelAdmin',
+        reloadOnUpdate: 500,
         fields: [{
             name: 'name',
             label: 'Log Name',

--- a/rest/data/RestStore.js
+++ b/rest/data/RestStore.js
@@ -19,12 +19,14 @@ import {RestField} from './RestField';
 export class RestStore extends UrlStore {
 
     _lookupsLoaded = false;
+    reloadOnUpdate = null;
 
     /**
      * Construct this object.
      */
-    constructor({dataRoot = 'data', ...rest}) {
+    constructor({reloadOnUpdate, dataRoot = 'data', ...rest}) {
         super({dataRoot, ...rest});
+        this.reloadOnUpdate = reloadOnUpdate;
     }
 
     get defaultFieldClass() {
@@ -66,6 +68,10 @@ export class RestStore extends UrlStore {
         return this.saveRecordInternalAsync(rec, false);
     }
 
+    async reload() {
+        return super.loadAsync();
+    }
+
     //--------------------------------
     // Implementation
     //--------------------------------
@@ -80,6 +86,7 @@ export class RestStore extends UrlStore {
         }).then(response => {
             const recs = this.createRecordMap([response.data]);
             this.updateRecordInternal(recs.values().next().value);
+            if (this.reloadOnUpdate) setTimeout(() => this.reload(), this.reloadOnUpdate);
         }).linkTo(
             this.loadModel
         );


### PR DESCRIPTION
Opening this for discussion. I don't think this is the correct solution. This seems like such a specific need for LogLevel panel, that adding this prop to all RestStores is overkill.

After I came to this conclusion I wanted to apply a fix using an event that would fire after saveRecordInternalAsync resolved, but firing/handling such an event turned out to be less straight forward than I imagined. 

Rather than burning a bunch of time trying to make that work, I figured I'd wait to see what you guys might have to say about it.