### PR TITLE
PropType check for menu item should be 'oneOfType'

### DIFF
--- a/cmp/contextmenu/ContextMenu.js
+++ b/cmp/contextmenu/ContextMenu.js
@@ -29,7 +29,7 @@ export class ContextMenu extends Component {
         /**
          *  Array of ContextMenuItems, configs to create them, Elements, or '-' (divider).
          */
-        menuItems: PT.arrayOf(PT.oneOf([PT.object, PT.string, PT.element]))
+        menuItems: PT.arrayOf(PT.oneOfType([PT.object, PT.string, PT.element]))
     }
 
     render() {


### PR DESCRIPTION
Saw the context menu throwing when testing an unrelated change.

We were using oneOf but:

"PropTypes.oneOf is a simple enum of literal values. It means that if you’re going to pass a value to this component, it better be one of these exact values."

Came across this:
https://github.com/facebook/react/issues/1919
https://jaketrent.com/post/react-oneof-vs-oneoftype/
