### PR TITLE
Do not set non-number values on hoist numberFields

### DIFF
--- a/cmp/form/NumberField.js
+++ b/cmp/form/NumberField.js
@@ -48,7 +48,8 @@ export class NumberField extends HoistField {
     }
 
     toExternal(val) {
-        return Number.parseFloat(val);
+        const ret = Number.parseFloat(val);
+        return isFinite(ret) ? ret : null;
     }
 
     toInternal(val) {

--- a/cmp/form/NumberField.js
+++ b/cmp/form/NumberField.js
@@ -53,7 +53,7 @@ export class NumberField extends HoistField {
     }
 
     toInternal(val) {
-        return val ? val.toString() : '';
+        return val != null ? val.toString() : '';
     }
 }
 export const numberField = elemFactory(NumberField);


### PR DESCRIPTION
The only way we were ending up with this problem was to either tab and then out of the field without entering any input or to delete preexisting input which would pass an empty string to parseFloat and give us 'NaN'.

This NaN value was invisible in the UI and was almost certainly not what was intended by the user.

This surfaced out of the type switching problem (where you see the left over value in a new control). I'm working on that in another branch but it seemed like this numberField behavior would still be wrong once that is fixed.