### PR TITLE
track service updates

### DIFF
--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -69,7 +69,9 @@ export class MonitorResultsModel {
         return XH
             .fetchJson({url: 'monitorAdmin/forceRunAllMonitors'})
             .then(
-                ToastManager.show({
+                // Wrapping the toast call in a function causes it to run only
+                // if the fetchJson was successful.
+                () => ToastManager.show({
                     message: 'Request received. Results will be generated shortly.'
                 })
             )

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -69,8 +69,6 @@ export class MonitorResultsModel {
         return XH
             .fetchJson({url: 'monitorAdmin/forceRunAllMonitors'})
             .then(
-                // Wrapping the toast call in a function causes it to run only
-                // if the fetchJson was successful.
                 () => ToastManager.show({
                     message: 'Request received. Results will be generated shortly.'
                 })

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -134,7 +134,6 @@ Object.assign(Promise.prototype, {
         const startTime = Date.now();
 
         return this.catch(e => {
-            trackCfg.exception = e;
             throw e;
         }).finally(() => {
             trackCfg.elapsed = Date.now() - startTime;

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -131,11 +131,13 @@ Object.assign(Promise.prototype, {
     track(trackCfg) {
         if (!trackCfg) return this;
 
+        if (typeof trackCfg === 'string') {
+            trackCfg = {msg: trackCfg};
+        }
+
         const startTime = Date.now();
 
-        return this.catch(e => {
-            throw e;
-        }).finally(() => {
+        return this.finally(() => {
             trackCfg.elapsed = Date.now() - startTime;
             XH.track(trackCfg);
         });

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -16,15 +16,21 @@ export class TrackService extends BaseService {
      *
      * @param {Object|string} options - if a string, it will become the msg value.
      * @param {string} [options.msg] - user-supplied message. Required if options is an object.
+     * @param {string} [options.message] - same as options.msg.  Just supporting msg & message. Use either, not both.
      * @param {string} [options.category] - user-supplied category.
      * @param {Object|Array} [options.data] - user-supplied data collection.
      * @param {number} [options.elapsed] - time in milliseconds some activity took.
-     * @param {string} [options.severity] - level flag, such as: OK|WARN|OMG
+     * @param {string} [options.severity] - importance flag, such as: OK|WARN|EMERGENCY
      *                 (errors should be tracked by the ErrorTrackingService, not sent
      *                 in this TrackService).
      */
     track(options) {
-        const params = {msg: stripTags(typeof options === 'string' ? options : options.msg)};
+        let msg = options;
+        if (typeof msg !== 'string') {
+            msg = options.msg !== undefined ? options.msg : options.message;
+        }
+
+        const params = {msg: stripTags(msg)};
         try {
             if (options.category)               params.category = options.category;
             if (options.data)                   params.data = JSON.stringify(options.data);

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -10,6 +10,19 @@ import {stripTags} from 'hoist/utils/HtmlUtils';
 
 export class TrackService extends BaseService {
 
+    /**
+     * Create a Track Log entry.
+     * Client metadata is set automatically by the server's parsing of request headers.
+     *
+     * @param {Object|string} options - if a string, it will become the msg value.
+     * @param {string} [options.msg] - user-supplied message. Required if options is an object.
+     * @param {string} [options.category] - user-supplied category.
+     * @param {Object|Array} [options.data] - user-supplied data collection.
+     * @param {number} [options.elapsed] - time in milliseconds some activity took.
+     * @param {string} [options.severity] - level flag, such as: OK|WARN|OMG
+     *                 (errors should be tracked by the ErrorTrackingService, not sent
+     *                 in this TrackService).
+     */
     track(options) {
         const params = {msg: stripTags(typeof options === 'string' ? options : options.msg)};
         try {
@@ -23,15 +36,8 @@ export class TrackService extends BaseService {
                     .filter(it => it != null)
                     .join(' | ');
 
-            const exception = options.exception;
-            if (exception) {
-                const exceptionMsg = exception.msg || exception.message || 'Unknown exception';
-                params.msg += ' | Error: ' + stripTags(exceptionMsg);
-                if (!params.severity) params.severity = 'ERROR';
-                console.error(consoleMsg, exception);
-            } else {
-                console.log(consoleMsg);
-            }
+            console.log(consoleMsg);
+
             XH.fetchJson({
                 url: 'hoistImpl/track',
                 params: params

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -11,18 +11,19 @@ import {stripTags} from 'hoist/utils/HtmlUtils';
 export class TrackService extends BaseService {
 
     /**
-     * Create a Track Log entry.
+     * Primary service for tracking any activity that an application's admins want to track.
+     * Activities are presented to admins in the Admin App's Client Activity > Activity grid.
      * Client metadata is set automatically by the server's parsing of request headers.
      *
-     * @param {Object|string} options - if a string, it will become the msg value.
-     * @param {string} [options.msg] - user-supplied message. Required if options is an object.
-     * @param {string} [options.message] - same as options.msg.  Just supporting msg & message. Use either, not both.
-     * @param {string} [options.category] - user-supplied category.
-     * @param {Object|Array} [options.data] - user-supplied data collection.
+     * @param ({Object|string}) options - if a string, it will become the message value.
+     * @param {string} options.msg - Short description of the activity being tracked.
+     *      Required if options is an object.
+     *      Can be passed as `message` for backwards compatibility.
+     * @param {string} [options.category] - app-supplied category.
+     * @param ({Object|Array}) [options.data] - app-supplied data collection.
      * @param {number} [options.elapsed] - time in milliseconds some activity took.
      * @param {string} [options.severity] - importance flag, such as: OK|WARN|EMERGENCY
-     *                 (errors should be tracked by the ErrorTrackingService, not sent
-     *                 in this TrackService).
+     *      (errors should be tracked by the ErrorTrackingService, not sent in this TrackService).
      */
     track(options) {
         let msg = options;


### PR DESCRIPTION
Removed exception property from the service.
Added doc, and added support for msg & messages.

In removing the exception property from the service, I was obliged to remove it from the promise's use of track.  The assumption being that we will just not log promise exceptions at all.  That may be the wrong assumption.