### PR TITLE
Send empty string in place of null as message for Client Error

### DIFF
--- a/svc/ErrorTrackingService.js
+++ b/svc/ErrorTrackingService.js
@@ -25,7 +25,7 @@ export class ErrorTrackingService extends BaseService {
             url: 'hoistImpl/submitError',
             params: {
                 error,
-                msg: message ? stripTags(message) : null,
+                msg: message ? stripTags(message) : '',
                 appVersion: XH.getEnv('appVersion')
             }
         });


### PR DESCRIPTION
This null was getting converted to a string by fetch, and then saved as such. I have a fix in place to handle this in hoist core, but better to not create the problem in the first place I think.