### PR TITLE
Only null out typeFields if form isDirty, Fixes #310

### DIFF
--- a/cmp/rest/RestControlModel.js
+++ b/cmp/rest/RestControlModel.js
@@ -25,7 +25,9 @@ export class RestControlModel  {
         if (field.typeField) {
             this.addReaction(
                 () => this.type,
-                () => this.setValue(null)
+                () => {
+                    if (this.parent.isDirty) this.setValue(null);
+                }
             );
         }
     }


### PR DESCRIPTION
This ensures that we do not null them out upon opening an edit form.