### PR TITLE
Dataview should refresh on data change

### DIFF
--- a/cmp/dataview/DataView.js
+++ b/cmp/dataview/DataView.js
@@ -23,8 +23,8 @@ class DataView extends Component {
             contextMenuFn,
             columns: [
                 baseCol({
-                    field: 'id',
                     flex: 1,
+                    valueGetter: (params) => params.data,
                     elementRenderer: (record) => {
                         return itemFactory({record: record.data});
                     }


### PR DESCRIPTION
Dataview should take the whole record as it's value, rather than the id, to ensure the cell refreshes on data change