### PR TITLE
Combofield fixes, Fixes #353, Fixes #354

### DIFF
--- a/cmp/form/dropdown/BaseComboField.js
+++ b/cmp/form/dropdown/BaseComboField.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {observable, setter, computed} from '@xh/hoist/mobx';
+import {observable, computed, action} from '@xh/hoist/mobx';
 import {debounce} from 'lodash';
 
 import {BaseDropdownField} from './BaseDropdownField';
@@ -17,7 +17,7 @@ import {BaseDropdownField} from './BaseDropdownField';
  */
 export class BaseComboField extends BaseDropdownField {
 
-    @observable @setter pendingCommit;
+    @observable pendingCommit;
 
     constructor(props) {
         super(props);
@@ -59,6 +59,11 @@ export class BaseComboField extends BaseDropdownField {
     doCommit() {
         super.doCommit();
         this.setPendingCommit(false);
+    }
+
+    @action
+    setPendingCommit(val) {
+        this.pendingCommit = val;
     }
 
     onChange = (ev) => {

--- a/cmp/form/dropdown/BaseComboField.js
+++ b/cmp/form/dropdown/BaseComboField.js
@@ -6,7 +6,7 @@
  */
 
 import {observable, setter, computed} from '@xh/hoist/mobx';
-import {debounce, find} from 'lodash';
+import {debounce} from 'lodash';
 
 import {BaseDropdownField} from './BaseDropdownField';
 

--- a/cmp/form/dropdown/BaseComboField.js
+++ b/cmp/form/dropdown/BaseComboField.js
@@ -5,7 +5,8 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {find} from 'lodash';
+import {observable, setter, computed} from '@xh/hoist/mobx';
+import {debounce, find} from 'lodash';
 
 import {BaseDropdownField} from './BaseDropdownField';
 
@@ -16,36 +17,48 @@ import {BaseDropdownField} from './BaseDropdownField';
  */
 export class BaseComboField extends BaseDropdownField {
 
-    onKeyPress = (ev) => {
-        if (ev.key === 'Enter') {
-            this.doCommit();
+    @observable @setter pendingCommit;
+
+    constructor(props) {
+        super(props);
+        // The debounce wait has to be quite long to account for the delayed onItemSelect event.
+        // This delay is masked to the user by rendering internalValue while pendingCommit.
+        this._debouncedCommit = debounce(this.doCommit, !props.requireSelection ? 200 : 0);
+    }
+
+    @computed
+    get renderValue() {
+        return this.hasFocus || this.pendingCommit ?
+            this.internalValue :
+            this.toInternal(this.externalValue);
+    }
+
+    onBlur = () => {
+        if (!this.props.requireSelection) {
+            this.doDebouncedCommit();
         }
+        this.setHasFocus(false);
+    }
+
+    onKeyPress = (ev) => {
+        if (ev.key === 'Enter' && !this.props.requireSelection) {
+            this.doDebouncedCommit();
+        }
+    }
+
+    onItemSelect = (val) => {
+        this.noteValueChange(val.value);
+        this.doDebouncedCommit();
+    }
+
+    doDebouncedCommit() {
+        this.setPendingCommit(true);
+        this._debouncedCommit();
     }
 
     doCommit() {
-        if (this.props.requireSelection) {
-            this.forceSelectionToOptionOrRevert();
-        }
         super.doCommit();
-    }
-
-    forceSelectionToOptionOrRevert() {
-        const {internalOptions, internalValue} = this;
-
-        // 0) We have a match, nothing to be done
-        if (find(internalOptions, {label: internalValue})) {
-            return;
-        }
-
-        // 1) Close enough, just adjust casing
-        const match = find(internalOptions, (it) => it.label.toLowerCase() == internalValue.toLowerCase());
-        if (match) {
-            this.noteValueChange(match.value);
-            return;
-        }
-
-        // 2) Otherwise, revert
-        this.noteValueChange(this.externalValue);
+        this.setPendingCommit(false);
     }
 
     onChange = (ev) => {

--- a/cmp/form/dropdown/BaseComboField.js
+++ b/cmp/form/dropdown/BaseComboField.js
@@ -11,9 +11,10 @@ import {debounce} from 'lodash';
 import {BaseDropdownField} from './BaseDropdownField';
 
 /**
- * BaseComboField
+ * Abstract superclass supporting ComboField and QueryComboField.
  *
- * Abstract class supporting ComboField, QueryComboField.
+ * This includes debouncing commits due to the multiple ways committing
+ * can be triggered from these fields (blur/enter/item select).
  */
 export class BaseComboField extends BaseDropdownField {
 
@@ -34,6 +35,12 @@ export class BaseComboField extends BaseDropdownField {
     }
 
     onBlur = () => {
+        // Combos that allow custom entries (!requireSelection) will commit those on blur.
+        // Note this could be confusing in the case where the user has entered enough text to cause
+        // the pop-up suggestion list to narrow down to a single item. It would be reasonable to
+        // think that tabbing out would select that value, but instead you get a new, custom value.
+        // Suggest we revisit this in the context of a more explicit inline "New" button for these
+        // combos that allow for on-the-fly entries, so it's more clear all around.
         if (!this.props.requireSelection) {
             this.doDebouncedCommit();
         }
@@ -41,6 +48,7 @@ export class BaseComboField extends BaseDropdownField {
     }
 
     onKeyPress = (ev) => {
+        // For Combos that requireSelection, <enter> must/will trigger onItemSelect to commit.
         if (ev.key === 'Enter' && !this.props.requireSelection) {
             this.doDebouncedCommit();
         }


### PR DESCRIPTION
+ Only attempt to commit onBlur and onKeyPress if !requireSelection. Allows us to remove label matching logic. Fixes #353.
+ Debounce commits. Display internalValue during wait to mask for user. Fixes #354.