### PR TITLE
AppBar Component

### DIFF
--- a/admin/App.js
+++ b/admin/App.js
@@ -6,15 +6,14 @@
  */
 
 import {Component} from 'react';
-import {navbar, navbarGroup, navbarHeading, button} from '@xh/hoist/kit/blueprint';
-import {XH, HoistComponent} from '@xh/hoist/core';
+import {button} from '@xh/hoist/kit/blueprint';
+import {HoistComponent, XH} from '@xh/hoist/core';
 import {lockoutPanel} from '@xh/hoist/app';
-import {tabContainer} from '@xh/hoist/cmp/tab';
+import {tabContainer, tabSwitcher} from '@xh/hoist/cmp/tab';
 import {frame, panel} from '@xh/hoist/cmp/layout';
-import {logoutButton, themeToggleButton, refreshButton} from '@xh/hoist/cmp/button';
+import {refreshButton} from '@xh/hoist/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {appBar} from '@xh/hoist/cmp/appbar';
-import {tabSwitcher} from '@xh/hoist/cmp/tab';
 
 import './App.scss';
 
@@ -44,7 +43,7 @@ export class App extends Component {
             leftItems: [
                 tabSwitcher({
                     model: this.model.tabs,
-                    large: false,
+                    large: false
                 })
             ],
             rightItems: [

--- a/admin/App.js
+++ b/admin/App.js
@@ -41,10 +41,7 @@ export class App extends Component {
             icon: Icon.gears({size: '2x'}),
             title: `${XH.appName} Admin`,
             leftItems: [
-                tabSwitcher({
-                    model: this.model.tabs,
-                    large: false
-                })
+                tabSwitcher({model: this.model.tabs})
             ],
             rightItems: [
                 button({

--- a/admin/App.js
+++ b/admin/App.js
@@ -11,7 +11,6 @@ import {HoistComponent, XH} from '@xh/hoist/core';
 import {lockoutPanel} from '@xh/hoist/app';
 import {tabContainer, tabSwitcher} from '@xh/hoist/cmp/tab';
 import {frame, panel} from '@xh/hoist/cmp/layout';
-import {refreshButton} from '@xh/hoist/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {appBar} from '@xh/hoist/cmp/appbar';
 
@@ -53,13 +52,13 @@ export class App extends Component {
                     icon: Icon.openExternal(),
                     title: 'Open app...',
                     onClick: this.onOpenAppClick
-                }),
-                refreshButton({
-                    intent: 'success',
-                    onClick: this.onRefreshClick
                 })
             ],
-            adminButton: false
+            adminButton: false,
+            refreshButtonProps: {
+                intent: 'success',
+                onClick: this.onRefreshClick
+            }
         });
     }
 

--- a/admin/App.js
+++ b/admin/App.js
@@ -13,6 +13,8 @@ import {tabContainer} from '@xh/hoist/cmp/tab';
 import {frame, panel} from '@xh/hoist/cmp/layout';
 import {logoutButton, themeToggleButton, refreshButton} from '@xh/hoist/cmp/button';
 import {Icon} from '@xh/hoist/icon';
+import {appBar} from '@xh/hoist/cmp/appbar';
+import {tabSwitcher} from '@xh/hoist/cmp/tab';
 
 import './App.scss';
 
@@ -36,49 +38,44 @@ export class App extends Component {
     // Implementation
     //------------------
     renderNavBar() {
-        return navbar({
-            items: [
-                navbarGroup({
-                    align: 'left',
-                    items: [
-                        Icon.gears({size: '2x'}),
-                        navbarHeading(`${XH.appName} Admin`)
-                    ]
-                }),
-                navbarGroup({
-                    align: 'right',
-                    items: [
-                        button({
-                            icon: Icon.mail(),
-                            text: 'Contact',
-                            onClick: this.onContactClick
-                        }),
-                        button({
-                            icon: Icon.openExternal(),
-                            title: 'Open app...',
-                            onClick: this.onOpenAppClick
-                        }),
-                        themeToggleButton(),
-                        logoutButton(),
-                        refreshButton({
-                            intent: 'success',
-                            onClick: this.onRefreshClick
-                        })
-                    ]
+        return appBar({
+            icon: Icon.gears({size: '2x'}),
+            title: `${XH.appName} Admin`,
+            leftItems: [
+                tabSwitcher({
+                    model: this.model.tabs,
+                    large: false,
                 })
-            ]
+            ],
+            rightItems: [
+                button({
+                    icon: Icon.mail(),
+                    text: 'Contact',
+                    onClick: this.onContactClick
+                }),
+                button({
+                    icon: Icon.openExternal(),
+                    title: 'Open app...',
+                    onClick: this.onOpenAppClick
+                }),
+                refreshButton({
+                    intent: 'success',
+                    onClick: this.onRefreshClick
+                })
+            ],
+            adminButton: false
         });
     }
 
     onContactClick = () => {
         window.open('https://xh.io/contact');
-    }
+    };
 
     onOpenAppClick = () => {
         window.open('/app');
-    }
+    };
 
     onRefreshClick = () => {
         XH.appModel.requestRefresh();
-    }
+    };
 }

--- a/admin/AppModel.js
+++ b/admin/AppModel.js
@@ -59,6 +59,7 @@ export class AppModel {
         return new TabContainerModel({
             id: 'default',
             useRoutes: true,
+            switcherPosition: 'none',
             children: this.createTabs()
         });
     }

--- a/cmp/appbar/AppBar.js
+++ b/cmp/appbar/AppBar.js
@@ -1,0 +1,73 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {Component} from 'react';
+import {PropTypes as PT} from 'prop-types';
+import {elemFactory, HoistComponent, XH} from '@xh/hoist/core';
+import {navbar, navbarGroup} from '@xh/hoist/kit/blueprint';
+import {launchAdminButton, logoutButton, themeToggleButton} from '@xh/hoist/cmp/button';
+import {span} from '@xh/hoist/cmp/layout';
+import {appBarSeparator} from '@xh/hoist/cmp/appbar';
+import {isEmpty} from 'lodash';
+import './AppBar.scss';
+
+/**
+ * A standard application navigation bar which displays the application name and a standard set of
+ * buttons for common application actions. Application specific items can be displayed on the left
+ * or right sides of the AppBar.
+ *
+ * The standard buttons which are visible will be based on user roles and application configuration,
+ * or they can each be explicitly hidden.
+ */
+@HoistComponent()
+export class AppBar extends Component {
+    static propTypes = {
+        /** Icon to display before the title. */
+        icon: PT.element,
+        /** Title to display to the left side of the AppBar. Defaults to the application name if not provided. */
+        title: PT.string,
+        /** Items to be added to the left side of the AppBar, immediately after the title. */
+        leftItems: PT.node,
+        /** Items to be added to the right side of the AppBar, before the standard buttons. */
+        rightItems: PT.node,
+        /** Set to true to hide the Launch Admin button. */
+        hideAdminButton: PT.bool,
+        /** Set to true to hide the Theme Toggle button. */
+        hideThemeButton: PT.bool,
+        /** Set to true to hide the Logout button. */
+        hideLogoutButton: PT.bool
+    };
+
+    render() {
+        const {icon, title, leftItems, rightItems, hideAdminButton, hideThemeButton, hideLogoutButton} = this.props;
+        return navbar({
+            cls: 'xh-appbar',
+            items: [
+                navbarGroup({
+                    align: 'left',
+                    items: [
+                        icon,
+                        span({cls: 'xh-appbar-title', item: title || XH.appName}),
+                        appBarSeparator({omit: isEmpty(leftItems)}),
+                        ...leftItems || []
+                    ]
+                }),
+                navbarGroup({
+                    align: 'right',
+                    items: [
+                        ...rightItems || [],
+                        themeToggleButton({omit: hideThemeButton}),
+                        launchAdminButton({omit: hideAdminButton}),
+                        logoutButton({omit: hideLogoutButton}),
+                    ]
+                })
+            ]
+        });
+    }
+}
+
+export const appBar = elemFactory(AppBar);

--- a/cmp/appbar/AppBar.js
+++ b/cmp/appbar/AppBar.js
@@ -14,6 +14,7 @@ import {span} from '@xh/hoist/cmp/layout';
 import {appBarSeparator} from '@xh/hoist/cmp/appbar';
 import {isEmpty} from 'lodash';
 import './AppBar.scss';
+import {refreshButton} from '../button/RefreshButton';
 
 /**
  * A standard application navigation bar which displays the application name and a standard set of
@@ -39,11 +40,15 @@ export class AppBar extends Component {
         /** Set to true to hide the Theme Toggle button. */
         hideThemeButton: PT.bool,
         /** Set to true to hide the Logout button. Will be automatically hidden for applications with logout disabled. */
-        hideLogoutButton: PT.bool
+        hideLogoutButton: PT.bool,
+        /** Set to true to hide the Refresh button. */
+        hideRefreshButton: PT.bool,
+        /** Allows overriding the default properties of the Refresh button. @see RefreshButton */
+        refreshButtonProps: PT.object
     };
 
     render() {
-        const {icon, title, leftItems, rightItems, hideAdminButton, hideThemeButton, hideLogoutButton} = this.props;
+        const {icon, title, leftItems, rightItems, hideAdminButton, hideThemeButton, hideLogoutButton, hideRefreshButton, refreshButtonProps = {}} = this.props;
         return navbar({
             cls: 'xh-appbar',
             items: [
@@ -62,7 +67,8 @@ export class AppBar extends Component {
                         ...rightItems || [],
                         themeToggleButton({omit: hideThemeButton}),
                         launchAdminButton({omit: hideAdminButton}),
-                        logoutButton({omit: hideLogoutButton})
+                        logoutButton({omit: hideLogoutButton}),
+                        refreshButton({omit: hideRefreshButton, ...refreshButtonProps})
                     ]
                 })
             ]

--- a/cmp/appbar/AppBar.js
+++ b/cmp/appbar/AppBar.js
@@ -30,15 +30,15 @@ export class AppBar extends Component {
         icon: PT.element,
         /** Title to display to the left side of the AppBar. Defaults to the application name if not provided. */
         title: PT.string,
-        /** Items to be added to the left side of the AppBar, immediately after the title. */
+        /** Items to be added to the left side of the AppBar, immediately after the title (or . */
         leftItems: PT.node,
         /** Items to be added to the right side of the AppBar, before the standard buttons. */
         rightItems: PT.node,
-        /** Set to true to hide the Launch Admin button. */
+        /** Set to true to hide the Launch Admin button. Will be automatically hidden for users without the HOIST_ADMIN role. */
         hideAdminButton: PT.bool,
         /** Set to true to hide the Theme Toggle button. */
         hideThemeButton: PT.bool,
-        /** Set to true to hide the Logout button. */
+        /** Set to true to hide the Logout button. Will be automatically hidden for applications with logout disabled. */
         hideLogoutButton: PT.bool
     };
 

--- a/cmp/appbar/AppBar.js
+++ b/cmp/appbar/AppBar.js
@@ -62,7 +62,7 @@ export class AppBar extends Component {
                         ...rightItems || [],
                         themeToggleButton({omit: hideThemeButton}),
                         launchAdminButton({omit: hideAdminButton}),
-                        logoutButton({omit: hideLogoutButton}),
+                        logoutButton({omit: hideLogoutButton})
                     ]
                 })
             ]

--- a/cmp/appbar/AppBar.scss
+++ b/cmp/appbar/AppBar.scss
@@ -1,0 +1,18 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+.xh-appbar {
+  .xh-appbar-title {
+    color: var(--xh-navbar-title-color);
+    font-size: var(--xh-navbar-title-font-size-px);
+    margin: 0 var(--xh-pad-px);
+  }
+
+  & > .pt-navbar-group > .svg-inline--fa {
+    margin: 0 5px 0 0;
+  }
+}

--- a/cmp/appbar/AppBarSeparator.js
+++ b/cmp/appbar/AppBarSeparator.js
@@ -1,0 +1,21 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {Component} from 'react';
+import {elemFactory} from '@xh/hoist/core';
+import {navbarDivider} from '@xh/hoist/kit/blueprint';
+
+/**
+ * Convenience component for adding a separator between AppBar items.
+ */
+export class AppBarSeparator extends Component {
+    render() {
+        return navbarDivider();
+    }
+}
+
+export const appBarSeparator = elemFactory(AppBarSeparator);

--- a/cmp/appbar/index.js
+++ b/cmp/appbar/index.js
@@ -1,0 +1,9 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+export * from './AppBar';
+export * from './AppBarSeparator';

--- a/cmp/tab/TabSwitcher.js
+++ b/cmp/tab/TabSwitcher.js
@@ -6,9 +6,10 @@
  */
 import {Component} from 'react';
 import {PropTypes as PT} from 'prop-types';
-import {elemFactory, HoistComponent} from '../../core';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
 import {tab, tabs} from '@xh/hoist/kit/blueprint';
 import {TabContainerModel} from './TabContainerModel';
+import {omit} from 'lodash';
 
 /**
  * Switcher display for a TabContainer.
@@ -18,8 +19,7 @@ import {TabContainerModel} from './TabContainerModel';
  *
  * The switcherPosition configuration on the TabContainerModel controls how this switcher will be
  * rendered. For 'top' or 'bottom' switcherPositions this switcher will be rendered in horizontal
- * and large mode. For 'left' or 'right' switcher positions this switcher will be rendered in
- * vertical mode.
+ * mode. For 'left' or 'right' switcher positions this switcher will be rendered in vertical mode.
  *
  * @see TabContainerModel
  */
@@ -37,10 +37,9 @@ export class TabSwitcher extends Component {
             id,
             vertical,
             onChange: this.onTabChange,
-            large: !vertical,
             selectedTabId: selectedId,
             items: children.map(({id, name}) => tab({id, title: name})),
-            ...this.props
+            ...omit(this.props, 'model')
         });
     }
 

--- a/cmp/tab/TabSwitcher.js
+++ b/cmp/tab/TabSwitcher.js
@@ -39,7 +39,8 @@ export class TabSwitcher extends Component {
             onChange: this.onTabChange,
             large: !vertical,
             selectedTabId: selectedId,
-            items: children.map(({id, name}) => tab({id, title: name}))
+            items: children.map(({id, name}) => tab({id, title: name})),
+            ...this.props
         });
     }
 


### PR DESCRIPTION
#307 

I left the built-in refresh button out since there isn't yet a consistent way to refresh an app, seems like that is a different story and the standard button can be added to AppBar once that mechanism is decided on.

I also updated the Admin app to put the TabSwitcher in the AppBar.

See https://github.com/exhi/toolbox/pull/18 for toolbox usage of the new component