### PR TITLE
Ensure TabContainer activeTabId is in sync with the router state (Fixes #451)

### DIFF
--- a/desktop/cmp/tab/container/TabContainerModel.js
+++ b/desktop/cmp/tab/container/TabContainerModel.js
@@ -6,7 +6,7 @@
  */
 import {HoistModel, XH} from '@xh/hoist/core';
 import {action, observable} from '@xh/hoist/mobx';
-import {isPlainObject, uniqBy, find} from 'lodash';
+import {find, isPlainObject, uniqBy} from 'lodash';
 import {throwIf} from '@xh/hoist/utils/JsUtils';
 import {TabModel} from '@xh/hoist/desktop/cmp/tab';
 
@@ -85,14 +85,14 @@ export class TabContainerModel {
 
         throwIf(!tab, `Unknown Tab ${id} in TabContainer.`);
 
-        this.activeTabId = id;
-        if (tab.reloadOnShow) tab.requestRefresh();
-
         if (route && !suppressRouting) {
             const tabRoute = route + '.' + id;
             if (!XH.router.isActive(tabRoute)) {
                 XH.navigate(tabRoute);
             }
+        } else {
+            this.activeTabId = id;
+            if (tab.reloadOnShow) tab.requestRefresh();
         }
     }
 

--- a/desktop/cmp/tab/pane/TabModel.js
+++ b/desktop/cmp/tab/pane/TabModel.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-import {XH, HoistModel} from '@xh/hoist/core';
+import {HoistModel, XH} from '@xh/hoist/core';
 import {action, computed, observable} from '@xh/hoist/mobx';
 import {LastPromiseModel} from '@xh/hoist/promise';
 import {startCase} from 'lodash';
@@ -46,7 +46,7 @@ export class TabModel {
     }
 
     activate() {
-        this.containerModel.setActiveTabId(this.id);
+        this.containerModel.activateTab(this.id);
     }
 
     get isActive() {

--- a/desktop/cmp/tab/switcher/TabSwitcher.js
+++ b/desktop/cmp/tab/switcher/TabSwitcher.js
@@ -52,7 +52,7 @@ export class TabSwitcher extends Component {
     }
 
     onTabChange = (activeTabId) => {
-        this.model.setActiveTabId(activeTabId);
+        this.model.activateTab(activeTabId);
     };
 }
 export const tabSwitcher = elemFactory(TabSwitcher);


### PR DESCRIPTION
#451 

Just a slight re-organization of the code for setting the `activeTabId` to allow the router state to drive updating the `activeTabId` value when using routing. This is to fix a sync issue where a route change could be rejected by middleware of a canDeactivate handler, and the TabContainer would still change the active tab.