### PR TITLE
Don't enforce focus on overlay unless covering entire viewport. Fixes #462

### DIFF
--- a/desktop/cmp/mask/LoadMask.js
+++ b/desktop/cmp/mask/LoadMask.js
@@ -7,8 +7,8 @@
 
 import {PropTypes as PT} from 'prop-types';
 import {Component} from 'react';
-import {HoistComponent, elemFactory} from '@xh/hoist/core';
-import {vbox, vspacer, box} from '@xh/hoist/cmp/layout';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
+import {box, vbox, vspacer} from '@xh/hoist/cmp/layout';
 import {Classes, overlay, spinner} from '@xh/hoist/kit/blueprint';
 
 import './Mask.scss';
@@ -41,6 +41,7 @@ export class LoadMask extends Component {
             isOpen: true,
             canEscapeKeyClose: false,
             usePortal: !isInline,
+            enforceFocus: !isInline,
             item: vbox({
                 cls: 'xh-mask-body',
                 items: [

--- a/desktop/cmp/mask/Mask.js
+++ b/desktop/cmp/mask/Mask.js
@@ -6,7 +6,7 @@
  */
 import {Component} from 'react';
 import {PropTypes as PT} from 'prop-types';
-import {HoistComponent, elemFactory} from '@xh/hoist/core';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
 import {box} from '@xh/hoist/cmp/layout';
 import {Classes, overlay} from '@xh/hoist/kit/blueprint';
 
@@ -34,6 +34,7 @@ export class Mask extends Component {
             isOpen: true,
             canEscapeKeyClose: false,
             usePortal: false,
+            enforceFocus: false,
             item: box({
                 cls: 'xh-mask-body',
                 item: text ? box({cls: 'xh-mask-text', item: text}) : null


### PR DESCRIPTION
This was easily reproduce-able in Toolbox on the components/loadMask page. Click the Load button and try to focus into the text boxes on the bottom toolbar.