### PR TITLE
Clear the selection when showing context menu for unselected record (Fixes #464)

### DIFF
--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -6,13 +6,12 @@
  */
 import {Component, isValidElement} from 'react';
 import {PropTypes as PT} from 'prop-types';
-import {find, isString, isNumber, isBoolean, isEqual, xor, merge} from 'lodash';
-import {XH} from '@xh/hoist/core';
-import {HoistComponent, elemFactory, LayoutSupport} from '@xh/hoist/core';
-import {fragment, box} from '@xh/hoist/cmp/layout';
+import {find, isBoolean, isEqual, isNumber, isString, merge, xor} from 'lodash';
+import {elemFactory, HoistComponent, LayoutSupport, XH} from '@xh/hoist/core';
+import {box, fragment} from '@xh/hoist/cmp/layout';
 import {convertIconToSvg, Icon} from '@xh/hoist/icon';
 import './ag-grid';
-import {navigateSelection, agGridReact} from './ag-grid';
+import {agGridReact, navigateSelection} from './ag-grid';
 import {colChooser} from './ColChooser';
 
 /**
@@ -165,7 +164,7 @@ class Grid extends Component {
         if (rec && !(recId in selectedIds)) {
             try {
                 this._scrollOnSelect = false;
-                selModel.select(rec, false);
+                selModel.select(rec);
             } finally {
                 this._scrollOnSelect = true;
             }


### PR DESCRIPTION
#464 

I enabled multi-select on the standard grid example in Toolbox for testing and to demonstrate the bug this is fixing.