### PR TITLE
Prevent automatic zooming upon input focus on mobile devices

### DIFF
--- a/template/index.html
+++ b/template/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, shrink-to-fit=no">
   <title><%= htmlWebpackPlugin.options.title %></title>
 </head>
 <body class="xh-app">


### PR DESCRIPTION
On mobile devices, the viewport automatically zooms upon focusing an input. This change prevents that by preventing scaling.

Tested on device in the context of a client-app. Does not seem to have any side-effects for desktop apps (i.e. user can still zoom using the browser zoom).

This _does_ break W3C accessibility guidelines (https://www.w3.org/TR/mobile-accessibility-mapping/#zoom-magnification), but I would argue they don't really apply, given that we are going for a 'native' app feel rather than an responsive app.