### PR TITLE
Wait for agGrid to finish updating its node model before attempting to sync selection.

### DIFF
--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -58,7 +58,6 @@ class Grid extends Component {
         this.addReaction(this.dataReaction());
     }
 
-
     render() {
         const {colChooserModel} = this.model,
             {layoutConfig, agOptions} = this.props;
@@ -122,7 +121,8 @@ class Grid extends Component {
             onSelectionChanged: this.onSelectionChanged,
             onSortChanged: this.onSortChanged,
             onGridSizeChanged: this.onGridSizeChanged,
-            onDragStopped: this.onDragStopped
+            onDragStopped: this.onDragStopped,
+            onRowDataUpdated: this.onRowDataUpdated
         };
     }
 
@@ -228,10 +228,10 @@ class Grid extends Component {
         const {model} = this;
 
         return {
-            track: () => [model.selection, model.agApi],
+            track: () => [model.selection, model.agApi, model.agNodesRendered],
             run: () => {
-                const {agApi, selModel} = model;
-                if (!agApi) return;
+                const {agApi, agNodesRendered, selModel} = model;
+                if (!agApi || !agNodesRendered) return;
 
                 const modelSelection = selModel.ids,
                     gridSelection = agApi.getSelectedRows().map(it => it.id),
@@ -286,6 +286,7 @@ class Grid extends Component {
             run: () => {
                 const {agApi} = model;
                 if (agApi) {
+                    model.setAgNodesRendered(false);
                     agApi.setRowData(model.store.records);
                 }
             }
@@ -304,6 +305,7 @@ class Grid extends Component {
     }
 
     onSelectionChanged = (ev) => {
+        if (!this.model.agNodesRendered) return;
         this.model.selModel.select(ev.api.getSelectedRows());
     }
 
@@ -321,5 +323,10 @@ class Grid extends Component {
             ev.api.sizeColumnsToFit();
         }
     }
+
+    onRowDataUpdated = () => {
+        this.model.setAgNodesRendered(true);
+    }
+
 }
 export const grid = elemFactory(Grid);

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -34,7 +34,7 @@ export class GridModel {
     @observable.ref columns = [];
     @observable.ref sortBy = [];
     @observable groupBy = null;
-
+    @observable agNodesRendered = false;
 
     defaultContextMenu = () => {
         return new StoreContextMenu({
@@ -169,6 +169,11 @@ export class GridModel {
     @action
     setAgApi(agApi) {
         this.agApi = agApi;
+    }
+
+    @action
+    setAgNodesRendered(val) {
+        this.agNodesRendered = val;
     }
 
     /**


### PR DESCRIPTION
There is an indeterminate short delay between `agApi.setRowData()` and agGrid's node model getting updated. In between these two times, the store's record collection and agGrid's internal node model are out of sync, and as such, any logic using agGrid's node model is unreliable. The delays in the client app were added to bandaid this, but are far from a robust solution.

This branch aims to make the 'readiness' of agGrid's node model observable via the new `agNodesRendered` prop (open to suggestions for better naming). This is set to false before setting rowData in the `dataReaction`, and set to true upon agGrid's `onRowDataUpdated` event.

Any code that works with agGrid's node model (i.e. selection syncing) should use this observable to determine if the node model is 'ready' and is a true reflection of the store model's records. Waiting for `agApi` is not enough for these types of functions.

Tested in client app and fixes #484