### PR TITLE
DayFields in Hoist Admin tabs commitOnChange

### DIFF
--- a/admin/tabs/activity/clienterrors/ClientErrorPanel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorPanel.js
@@ -77,6 +77,7 @@ export class ClientErrorPanel extends Component {
         return dayField({
             model: this.model,
             onCommit: this.onCommit,
+            commitOnChange: true,
             popoverPosition: 'bottom',
             width: 100,
             ...args

--- a/admin/tabs/activity/tracking/ActivityGrid.js
+++ b/admin/tabs/activity/tracking/ActivityGrid.js
@@ -79,6 +79,7 @@ export class ActivityGrid extends Component {
             popoverPosition: 'bottom',
             width: 100,
             onCommit: this.onCommit,
+            commitOnChange: true,
             ...args
         });
     }

--- a/admin/tabs/activity/tracking/VisitsChart.js
+++ b/admin/tabs/activity/tracking/VisitsChart.js
@@ -55,6 +55,7 @@ export class VisitsChart extends Component {
             model: this.model,
             onCommit: this.onCommit,
             popoverPosition: 'top-left',
+            commitOnChange: true,
             width: 100,
             ...args
         });

--- a/desktop/cmp/form/HoistField.js
+++ b/desktop/cmp/form/HoistField.js
@@ -31,7 +31,6 @@ import {observable, computed, action, runInAction} from '@xh/hoist/mobx';
  * The 'commitOnChange' property defaults to false, except for selected controls, such as CheckField
  * where a true value is more intuitive.  Furthermore, a commitOnChange value of false is not currently
  * implemented on DropdownFields and ComboBoxes. See BaseDropdownField for more information.
-
  *
  * Note that operating in bound mode may allow for more efficient rendering
  * in a mobx context, in that the bound value is only read *within* this
@@ -46,7 +45,6 @@ export class HoistField extends Component {
 
         /** value of the control */
         value: PT.any,
-
         /** handler to fire when value changes, gets passed the new value */
         onChange: PT.func,
         /** handler to fire when value is committed, gets passed the new value */


### PR DESCRIPTION
Seems like it's possible dayFields should be commitOnBlur by default instead. But for now this fixes https://github.com/exhi/hoist-react/issues/513