### PR TITLE
Global App refresh method + default AppBar RefreshButton handler

### DIFF
--- a/admin/App.js
+++ b/admin/App.js
@@ -5,7 +5,6 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 import {HoistApp, XH} from '@xh/hoist/core';
-import {action} from '@xh/hoist/mobx';
 import {AppContainer} from '@xh/hoist/desktop/appcontainer';
 import {TabContainerModel} from '@xh/hoist/desktop/cmp/tab';
 
@@ -36,7 +35,6 @@ export class App {
 
     get idleDetectionDisabled() {return true}
 
-    @action
     requestRefresh() {
         this.tabModel.requestRefresh();
     }

--- a/admin/AppComponent.js
+++ b/admin/AppComponent.js
@@ -12,7 +12,7 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {appBar} from '@xh/hoist/desktop/cmp/appbar';
-import {ContextMenuSupport, ContextMenuItem} from '@xh/hoist/desktop/cmp/contextmenu';
+import {ContextMenuItem, ContextMenuSupport} from '@xh/hoist/desktop/cmp/contextmenu';
 
 import './App.scss';
 
@@ -58,10 +58,7 @@ export class AppComponent extends Component {
                 })
             ],
             hideAdminButton: true,
-            hideFeedbackButton: true,
-            refreshButtonProps: {
-                onClick: this.onRefreshClick
-            }
+            hideFeedbackButton: true
         });
     }
 
@@ -71,9 +68,5 @@ export class AppComponent extends Component {
 
     onOpenAppClick = () => {
         window.open('/app');
-    };
-
-    onRefreshClick = () => {
-        XH.app.requestRefresh();
     };
 }

--- a/admin/tabs/activity/tracking/ActivityGrid.js
+++ b/admin/tabs/activity/tracking/ActivityGrid.js
@@ -60,7 +60,7 @@ export class ActivityGrid extends Component {
             this.textField({field: 'category', placeholder: 'Category...'}),
             this.textField({field: 'device', placeholder: 'Device...'}),
             this.textField({field: 'browser', placeholder: 'Browser...'}),
-            refreshButton({model, icon: Icon.portfolio(), title: 'poop'}),
+            refreshButton({model}),
             filler(),
             storeCountLabel({
                 store: model.gridModel.store,

--- a/admin/tabs/activity/tracking/ActivityGrid.js
+++ b/admin/tabs/activity/tracking/ActivityGrid.js
@@ -5,11 +5,11 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 import {Component} from 'react';
-import {HoistComponent, elemFactory} from '@xh/hoist/core';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
 import {grid} from '@xh/hoist/desktop/cmp/grid';
 import {filler} from '@xh/hoist/cmp/layout';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {textField, dayField} from '@xh/hoist/desktop/cmp/form';
+import {dayField, textField} from '@xh/hoist/desktop/cmp/form';
 import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
 import {button, exportButton, refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {storeCountLabel} from '@xh/hoist/desktop/cmp/store';
@@ -60,7 +60,7 @@ export class ActivityGrid extends Component {
             this.textField({field: 'category', placeholder: 'Category...'}),
             this.textField({field: 'device', placeholder: 'Device...'}),
             this.textField({field: 'browser', placeholder: 'Browser...'}),
-            refreshButton({model}),
+            refreshButton({model, icon: Icon.portfolio(), title: 'poop'}),
             filler(),
             storeCountLabel({
                 store: model.gridModel.store,

--- a/core/HoistApp.js
+++ b/core/HoistApp.js
@@ -114,7 +114,15 @@ export function HoistApp(C) {
          */
         getRoutes() {
             return [];
-        }
+        },
+
+        /**
+         * App can implement this method to customize global App refresh behavior.
+         * This is called by the default refresh button in the AppBar component.
+         *
+         * @param {boolean} userInitiated whether the refresh was triggered by user action or triggered programmatically
+         */
+        requestRefresh(userInitiated) { }
     });
 
     return C;

--- a/desktop/cmp/appbar/AppBar.js
+++ b/desktop/cmp/appbar/AppBar.js
@@ -28,24 +28,31 @@ export class AppBar extends Component {
     static propTypes = {
         /** Icon to display before the title. */
         icon: PT.element,
-        /** Title to display to the left side of the AppBar. Defaults to the application name if not provided. */
+        /**
+         * Title to display to the left side of the AppBar. Defaults to the application name if not
+         * provided.
+         */
         title: PT.string,
         /** Items to be added to the left side of the AppBar, immediately after the title (or . */
         leftItems: PT.node,
         /** Items to be added to the right side of the AppBar, before the standard buttons. */
         rightItems: PT.node,
-        /** Set to true to hide the Launch Admin button. Will be automatically hidden for users without the HOIST_ADMIN role. */
+        /**
+         * Set to true to hide the Launch Admin button. Will be automatically hidden for users
+         * without the HOIST_ADMIN role.
+         */
         hideAdminButton: PT.bool,
         /** Set to true to hide the Feedback button. */
         hideFeedbackButton: PT.bool,
         /** Set to true to hide the Theme Toggle button. */
         hideThemeButton: PT.bool,
-        /** Set to true to hide the Logout button. Will be automatically hidden for applications with logout disabled. */
+        /**
+         * Set to true to hide the Logout button. Will be automatically hidden for applications with
+         * logout disabled.
+         */
         hideLogoutButton: PT.bool,
         /** Set to true to hide the Refresh button. */
-        hideRefreshButton: PT.bool,
-        /** Allows overriding the default properties of the Refresh button. @see RefreshButton */
-        refreshButtonProps: PT.object
+        hideRefreshButton: PT.bool
     };
 
     baseClassName = 'xh-appbar';
@@ -60,8 +67,7 @@ export class AppBar extends Component {
             hideFeedbackButton,
             hideThemeButton,
             hideLogoutButton,
-            hideRefreshButton,
-            refreshButtonProps = {}
+            hideRefreshButton
         } = this.props;
 
         return navbar({
@@ -87,7 +93,7 @@ export class AppBar extends Component {
                         refreshButton({
                             omit: hideRefreshButton,
                             intent: 'success',
-                            ...refreshButtonProps
+                            onClick: () => XH.app.requestRefresh(true)
                         })
                     ]
                 })

--- a/desktop/cmp/button/RefreshButton.js
+++ b/desktop/cmp/button/RefreshButton.js
@@ -29,28 +29,20 @@ export class RefreshButton extends Component {
         title: PT.string,
         /** Function to call when the button is clicked. */
         onClick: PT.func,
-        /**
-         * Model to call loadAsync() on when the button is clicked. Only used if onClick was not
-         * provided.
-         */
+        /** Model to refresh via loadAsync(), if onClick prop not provided. */
         model: PT.object
     };
 
     render() {
         warnIf(
-            this.props.model && this.props.onClick,
-            'Both model and onClick were provided to RefreshButton properties. The model property will be ignored.'
-        );
-
-        warnIf(
-            !this.props.model && !this.props.onClick,
-            'Neither onClick nor model were provided to RefreshButton. Clicking the RefreshButton will have no effect.'
+            (this.props.model && this.props.onClick) || (!this.props.model && !this.props.onClick),
+            'RefreshButton must be provided either a model or an onClick handler to call (but not both).'
         );
 
         const {
             icon = Icon.sync(),
             title = 'Refresh',
-            onClick = this.model ? this.onRefreshClick : undefined,
+            onClick = this.model ? this.refreshModel : undefined,
             ...rest
         } = this.props;
 
@@ -65,7 +57,7 @@ export class RefreshButton extends Component {
     //---------------------------
     // Implementation
     //---------------------------
-    onRefreshClick = () => {
+    refreshModel = () => {
         this.model.loadAsync();
     };
 

--- a/desktop/cmp/button/RefreshButton.js
+++ b/desktop/cmp/button/RefreshButton.js
@@ -9,7 +9,7 @@ import {Component} from 'react';
 import {PropTypes as PT} from 'prop-types';
 import {elemFactory, HoistComponent} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
-import {button} from '@xh/hoist/kit/blueprint';
+import {button} from './Button';
 
 /**
  * Convenience Button preconfigured for use as a trigger for a refresh operation.
@@ -22,18 +22,25 @@ import {button} from '@xh/hoist/kit/blueprint';
 export class RefreshButton extends Component {
 
     static propTypes = {
+        /** Icon to display for the button. Defaults to Icon.sync(). */
         icon: PT.element,
+        /** Tooltip text to display when the mouse is over the button. Defaults to 'Refresh'. */
         title: PT.string,
+        /** Function to call when the button is clicked. Should only be used if not passing model. */
         onClick: PT.func,
+        /**
+         * Model to call loadAsync() on when the button is clicked. Should only be used if not
+         * using the onClick property.
+         */
         model: PT.object
     };
 
     render() {
-        const {icon, title, onClick, model, ...rest} = this.props;
+        const {icon = Icon.sync(), title = 'Refresh', onClick = this.onRefreshClick, ...rest} = this.props;
         return button({
-            icon: icon || Icon.sync(),
-            title: title || 'Refresh',
-            onClick: onClick || this.onRefreshClick,
+            icon,
+            title,
+            onClick,
             ...rest
         });
     }

--- a/desktop/cmp/button/RefreshButton.js
+++ b/desktop/cmp/button/RefreshButton.js
@@ -10,13 +10,14 @@ import {PropTypes as PT} from 'prop-types';
 import {elemFactory, HoistComponent} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {button} from './Button';
+import {warnIf} from '@xh/hoist/utils/JsUtils';
 
 /**
  * Convenience Button preconfigured for use as a trigger for a refresh operation.
  * Accepts props documented below as well as any others supported by Blueprint's Button.
  *
- * Must be provided either an onClick handler *or* a model. If a model is provided, this button
- * will call loadAsync() on the model class.
+ * Must be provided either an onClick handler *or* a model. If a model is provided and an onClick
+ * handler is not provided, this button will call loadAsync() on the model class.
  */
 @HoistComponent()
 export class RefreshButton extends Component {
@@ -26,17 +27,33 @@ export class RefreshButton extends Component {
         icon: PT.element,
         /** Tooltip text to display when the mouse is over the button. Defaults to 'Refresh'. */
         title: PT.string,
-        /** Function to call when the button is clicked. Should only be used if not passing model. */
+        /** Function to call when the button is clicked. */
         onClick: PT.func,
         /**
-         * Model to call loadAsync() on when the button is clicked. Should only be used if not
-         * using the onClick property.
+         * Model to call loadAsync() on when the button is clicked. Only used if onClick was not
+         * provided.
          */
         model: PT.object
     };
 
     render() {
-        const {icon = Icon.sync(), title = 'Refresh', onClick = this.onRefreshClick, ...rest} = this.props;
+        warnIf(
+            this.props.model && this.props.onClick,
+            'Both model and onClick were provided to RefreshButton properties. The model property will be ignored.'
+        );
+
+        warnIf(
+            !this.props.model && !this.props.onClick,
+            'Neither onClick nor model were provided to RefreshButton. Clicking the RefreshButton will have no effect.'
+        );
+
+        const {
+            icon = Icon.sync(),
+            title = 'Refresh',
+            onClick = this.model ? this.onRefreshClick : undefined,
+            ...rest
+        } = this.props;
+
         return button({
             icon,
             title,
@@ -45,12 +62,13 @@ export class RefreshButton extends Component {
         });
     }
 
-    //-------------------------
+    //---------------------------
     // Implementation
     //---------------------------
     onRefreshClick = () => {
         this.model.loadAsync();
-    }
+    };
 
 }
+
 export const refreshButton = elemFactory(RefreshButton);


### PR DESCRIPTION
#390 

Went with `requestRefresh` method on the App since that was the pattern we are following with the Tabs (and was already what the Admin app was using). Decided against using an event for now since we don't really seem to be using events much, and the App will probably need to drive the refresh from the top-down most of the time.