### PR TITLE
Cast headerClass and cellClass to array before pushing to it

### DIFF
--- a/columns/Column.js
+++ b/columns/Column.js
@@ -6,7 +6,7 @@
  */
 
 import {Component} from 'react';
-import {startCase} from 'lodash';
+import {castArray, startCase} from 'lodash';
 import {ExportFormat} from './ExportFormat';
 import {withDefault, withDefaultTrue, withDefaultFalse, throwIf, warnIf} from '@xh/hoist/utils/JsUtils';
 
@@ -105,8 +105,8 @@ export class Column {
 
         const {align} = this;
         if (align === 'center' || align === 'right') {
-            ret.headerClass = ret.headerClass || [];
-            ret.cellClass = ret.cellClass || [];
+            ret.headerClass = castArray(ret.headerClass) || [];
+            ret.cellClass = castArray(ret.cellClass) || [];
             ret.headerClass.push('xh-column-header-align-'+align);
             ret.cellClass.push('xh-align-'+align);
         }


### PR DESCRIPTION
These props can be specified as strings (in our agOptions) as documented by ag-grid. However, if passing a string here along with an align prop, our method was throwing when we tried to push our xh alignment class onto that string.