### PR TITLE
Doc updates (focus on Grid, Column, and related)

### DIFF
--- a/columns/Column.js
+++ b/columns/Column.js
@@ -26,40 +26,44 @@ export class Column {
      * @param {string} [c.colId] - unique identifier for the Column within its grid.
      *      Defaults to field name - one of these two properties must be specified.
      * @param {string} [c.headerName] - display text for grid header.
-     * @param {boolean} [c.hide]
+     * @param {boolean} [c.hide] - true to suppress default display of the column.
      * @param {string} [c.align] - horizontal alignment of cell contents.
      * @param {number} [c.width] - default width in pixels.
-     * @param {number} [c.minWidth]
-     * @param {number} [c.maxWidth]
+     * @param {number} [c.minWidth] - minimum width in pixels - grid will block user-driven as well
+     *      as auto-flex resizing below this value. (Note this is *not* a substitute for width.)
+     * @param {number} [c.maxWidth] - maximum width in pixels - grid will block user-driven as well
+     *      as auto-flex resizing above this value.
      * @param {boolean} [c.flex] - true to auto-adjust column width based on space available
      *      within the overall grid. Flex columns are not user-resizable as they will dynamically
-     *      adjust whenever the grid is resized to absorb available space.
-     * @param {boolean} [c.resizable] - set to false to prevent user from drag-and-drop resizing.
-     * @param {boolean} [c.movable] - set to false to prevent user from drag-and-drop re-ordering.
+     *      adjust whenever the grid changes size to absorb available horizontal space.
+     * @param {boolean} [c.resizable] - false to prevent user from drag-and-drop resizing.
+     * @param {boolean} [c.movable] - false to prevent user from drag-and-drop re-ordering.
      * @param {gridRenderer} [c.renderer] - function to produce a formatted string for each cell.
      *      Supports HTML as output. Passed both field value and entire row data object.
      * @param {function} [c.elementRenderer] - elementFactory function to return a React component
-     *      to rendering within each cell. For ag-Grid implementations, an ICellRendererParams
+     *      for rendering within each cell. For ag-Grid implementations, an ICellRendererParams
      *      object is passed to the rendered component as props.
      *      @see ICellRendererParams
      * @param {string} [c.chooserName] - name to display within the column chooser component.
-     *      Defaults to headerName, useful when a longer / un-abbreviated string is available.
+     *      Defaults to headerName, but useful when a longer / un-abbreviated string is available.
      * @param {string} [c.chooserGroup] - group name to display within the column chooser component.
      *      Chooser will automatically group its "available columns" grid if any cols provide.
      * @param {string} [c.chooserDescription] - additional descriptive text to display within the
      *      column chooser. Appears when the column is selected within the chooser UI.
      * @param {boolean} [c.excludeFromChooser] - true to hide the column from the column chooser
      *      completely. Useful for hiding structural columns the user is not expected to adjust.
-     * @param {string} [c.exportName] - display/header name within a file export.
+     * @param {string} [c.exportName] - display name to use as a header within a file export.
      *      Defaults to headerName.
      * @param {(string|function)} [c.exportValue] - alternate field name to reference or function
      *      to call when producing a value for a file export.
      *      @see ExportManager
      * @param {ExportFormat} [c.exportFormat] - structured format string for Excel-based exports.
+     *      @see ExportFormat
      * @param {boolean} [c.excludeFromExport] - true to drop this column from a file export.
      * @param {Object} [c.agOptions] - "escape hatch" object to pass directly to Ag-Grid for
      *      desktop implementations. Note these options may be used / overwritten by the framework
      *      itself, and are not all guaranteed to be compatible with its usages of Ag-Grid.
+     *      @see {@link https://www.ag-grid.com/javascript-grid-column-properties/|AG-Grid docs}
      */
     constructor({
         field,
@@ -175,8 +179,8 @@ export class Column {
 
 /**
  * @callback gridRenderer - normalized renderer function for a grid column cell.
- * @param {*} value - cell data value (column + row)
- * @param {Object} data - row data object (entire row)
+ * @param {*} value - cell data value (column + row).
+ * @param {Object} data - row data object (entire row).
  * @param {Object} metadata - additional data available to the renderer,
  *      currently contains the Column's string colId.
  * @return {string} - the formatted value for display.

--- a/columns/Column.js
+++ b/columns/Column.js
@@ -11,7 +11,9 @@ import {ExportFormat} from './ExportFormat';
 import {withDefault, withDefaultTrue, withDefaultFalse, throwIf, warnIf} from '@xh/hoist/utils/JsUtils';
 
 /**
- * Definition of display and other meta-data for a grid column.
+ * Cross-platform definition and API for a standardized Grid column.
+ * Typically provided to GridModels as plain configuration objects.
+ * @alias HoistColumn
  */
 export class Column {
 
@@ -19,7 +21,45 @@ export class Column {
     static FLEX_COL_MIN_WIDTH = 30;
 
     /**
-     * Create a new column.
+     * @param {Object} c - Column configuration.
+     * @param {string} [c.field] - name of data store field to display within the column.
+     * @param {string} [c.colId] - unique identifier for the Column within its grid.
+     *      Defaults to field name - one of these two properties must be specified.
+     * @param {string} [c.headerName] - display text for grid header.
+     * @param {boolean} [c.hide]
+     * @param {string} [c.align] - horizontal alignment of cell contents.
+     * @param {number} [c.width] - default width in pixels.
+     * @param {number} [c.minWidth]
+     * @param {number} [c.maxWidth]
+     * @param {boolean} [c.flex] - true to auto-adjust column width based on space available
+     *      within the overall grid. Flex columns are not user-resizable as they will dynamically
+     *      adjust whenever the grid is resized to absorb available space.
+     * @param {boolean} [c.resizable] - set to false to prevent user from drag-and-drop resizing.
+     * @param {boolean} [c.movable] - set to false to prevent user from drag-and-drop re-ordering.
+     * @param {gridRenderer} [c.renderer] - function to produce a formatted string for each cell.
+     *      Supports HTML as output. Passed both field value and entire row data object.
+     * @param {function} [c.elementRenderer] - elementFactory function to return a React component
+     *      to rendering within each cell. For ag-Grid implementations, an ICellRendererParams
+     *      object is passed to the rendered component as props.
+     *      @see ICellRendererParams
+     * @param {string} [c.chooserName] - name to display within the column chooser component.
+     *      Defaults to headerName, useful when a longer / un-abbreviated string is available.
+     * @param {string} [c.chooserGroup] - group name to display within the column chooser component.
+     *      Chooser will automatically group its "available columns" grid if any cols provide.
+     * @param {string} [c.chooserDescription] - additional descriptive text to display within the
+     *      column chooser. Appears when the column is selected within the chooser UI.
+     * @param {boolean} [c.excludeFromChooser] - true to hide the column from the column chooser
+     *      completely. Useful for hiding structural columns the user is not expected to adjust.
+     * @param {string} [c.exportName] - display/header name within a file export.
+     *      Defaults to headerName.
+     * @param {(string|function)} [c.exportValue] - alternate field name to reference or function
+     *      to call when producing a value for a file export.
+     *      @see ExportManager
+     * @param {ExportFormat} [c.exportFormat] - structured format string for Excel-based exports.
+     * @param {boolean} [c.excludeFromExport] - true to drop this column from a file export.
+     * @param {Object} [c.agOptions] - "escape hatch" object to pass directly to Ag-Grid for
+     *      desktop implementations. Note these options may be used / overwritten by the framework
+     *      itself, and are not all guaranteed to be compatible with its usages of Ag-Grid.
      */
     constructor({
         field,
@@ -33,7 +73,6 @@ export class Column {
         flex,
         resizable,
         movable,
-        format,
         renderer,
         elementRenderer,
         chooserName,
@@ -46,10 +85,9 @@ export class Column {
         excludeFromExport,
         agOptions
     }) {
-
         this.field = field;
         this.colId = withDefault(colId, field);
-        throwIf(!this.colId, 'Must specify colId or field in Column.');
+        throwIf(!this.colId, 'Must specify colId or field for a Column.');
 
         this.headerName = withDefault(headerName, startCase(this.colId));
         this.hide = withDefaultFalse(hide);
@@ -90,7 +128,6 @@ export class Column {
      * Produce a Column definition appropriate for AG Grid.
      */
     getAgSpec() {
-
         const ret = {
             field: this.field,
             colId: this.colId,
@@ -135,3 +172,12 @@ export class Column {
         return ret;
     }
 }
+
+/**
+ * @callback gridRenderer - normalized renderer function for a grid column cell.
+ * @param {*} value - cell data value (column + row)
+ * @param {Object} data - row data object (entire row)
+ * @param {Object} metadata - additional data available to the renderer,
+ *      currently contains the Column's string colId.
+ * @return {string} - the formatted value for display.
+ */

--- a/columns/ExportFormat.js
+++ b/columns/ExportFormat.js
@@ -7,7 +7,8 @@
 
 /**
  * Data-type specific cell formats used in server-side Excel exports.
- * Specify on a column definition via the `exportFormat` config.
+ * Specify for a Grid Column via the `Column.exportFormat` config.
+ * @enum {string}
  */
 export const ExportFormat = {
     DEFAULT:            'General',

--- a/core/AppState.js
+++ b/core/AppState.js
@@ -8,8 +8,8 @@
 
 /**
  * Enumeration of possible App States
- *
- * @see XH.appState.
+ * @enum {string}
+ * @see XHClass.appState
  */
 export const AppState = {
     PRE_AUTH:       'PRE_AUTH',

--- a/core/XH.js
+++ b/core/XH.js
@@ -202,10 +202,10 @@ class XHClass {
     /**
      * Show a modal message dialog.
      *
-     * @param {Object} [config] - options for message to be displayed
+     * @param {Object} config - message options.
      * @param {string} config.message - message text to be displayed.
      * @param {string} [config.title] - title of message box.
-     * @param {element} [config.icon] - icon to be displayed.
+     * @param {Element} [config.icon] - icon to be displayed.
      * @param {string} [config.confirmText] - Text for confirm button. If null, no button will be shown.
      * @param {string} [config.cancelText] - Text for cancel button. If null, no button will be shown.
      * @param {string} [config.confirmIntent] - Blueprint Intent for confirm button (desktop only).
@@ -221,7 +221,7 @@ class XHClass {
     /**
      * Show a modal 'alert' dialog with message and default 'OK' button.
      *
-     * @param {Object} config -  see XH.message() for available options.
+     * @param {Object} config - see XH.message() for available options.
      * @returns {Promise} - A Promise that will resolve to true when user acknowledges alert.
      */
     alert(config) {
@@ -244,24 +244,22 @@ class XHClass {
     /**
      * Handle an exception.
      *
-     * This method may be called by applications in order to provide logging, reporting, and display of
-     * exceptions.  It it typically called directly in catch() blocks.
+     * This method may be called by applications in order to provide logging, reporting,
+     * and display of exceptions.  It it typically called directly in catch() blocks.
      *
-     * This method is an alias for ExceptionHandler.handleException(). See that method for more information
-     * about available options.
+     * This method is an alias for ExceptionHandler.handleException(). See that method for more
+     * information about available options.
      *
-     * See also Promise.catchDefault().  That method will delegate its arguments to this method and provides a
-     * more convenient interface for Promise-based code.
+     * See also Promise.catchDefault(). That method will delegate its arguments to this method
+     * and provides a more convenient interface for Promise-based code.
      */
-    handleException(...args) {
-        return this.exceptionHandler.handleException(...args);
+    handleException(exception, options) {
+        return this.exceptionHandler.handleException(exception, options);
     }
 
     /**
      * Create a new exception.
-     *
-     * This method is an alias for the static method Exception.create().
-     * See that method for more information.
+     * @see Exception.create
      */
     exception(...args) {
         return Exception.create(...args);
@@ -308,15 +306,15 @@ class XHClass {
     //----------------------------
     // Service Aliases
     //----------------------------
-    track(...args)          {return this.trackService.track(...args)}
-    fetch(...args)          {return this.fetchService.fetch(...args)}
-    fetchJson(...args)      {return this.fetchService.fetchJson(...args)}
-    getUser(...args)        {return this.identityService.getUser(...args)}
-    getUsername(...args)    {return this.identityService.getUsername(...args)}
-    getConf(...args)        {return this.configService.get(...args)}
-    getPref(...args)        {return this.prefService.get(...args)}
-    setPref(...args)        {return this.prefService.set(...args)}
-    getEnv(...args)         {return this.environmentService.get(...args)}
+    track(opts)                 {return this.trackService.track(opts)}
+    fetch(opts)                 {return this.fetchService.fetch(opts)}
+    fetchJson(opts)             {return this.fetchService.fetchJson(opts)}
+    getUser()                   {return this.identityService.getUser()}
+    getUsername()               {return this.identityService.getUsername()}
+    getConf(key, defaultVal)    {return this.configService.get(key, defaultVal)}
+    getPref(key, defaultVal)    {return this.prefService.get(key, defaultVal)}
+    setPref(key, val)           {return this.prefService.set(key, val)}
+    getEnv(key)                 {return this.environmentService.get(key)}
 
 
     /**
@@ -454,4 +452,3 @@ class XHClass {
     }
 }
 export const XH = window.XH = new XHClass();
-

--- a/data/BaseStore.js
+++ b/data/BaseStore.js
@@ -10,29 +10,34 @@ import {XH} from '@xh/hoist/core';
 import {Field} from './Field';
 
 /**
- * A managed observable set of Records.
- * @abstract - see LocalStore or UrlStore for concrete implementations.
+ * A managed and observable set of Records.
+ * @see LocalStore
+ * @see UrlStore
+ * @abstract
  */
 export class BaseStore {
 
-    /** List of fields contained in each record.  **/
+    /**
+     * Fields contained in each record.
+     * @type {HoistField[]}
+     */
     fields = null;
 
-    /** Get a specific field, by name.  **/
+    /** Get a specific field, by name. */
     getField(name) {
         return this.fields.find(it => it.name === name);
     }
 
-    /** Current loading state. **/
+    /** Current loading state. */
     get loadModel() {}
 
-    /** Current records. These represent the post-filtered records. **/
+    /** Current records. These represent the post-filtered records. */
     get records() {}
 
-    /** All records.  These are the pre-filtered records. **/
+    /** All records.  These are the pre-filtered records. */
     get allRecords() {}
 
-    /** Filter.  Filter function to be applied. **/
+    /** Filter.  Filter function to be applied. */
     get filter() {}
     setFilter(filterFn) {}
 
@@ -40,13 +45,13 @@ export class BaseStore {
      * Get a record by ID. Return null if no record found.
      *
      * @param {number} id
-     * @param {boolean} filteredOnly - set to true to skip non-filtered records
+     * @param {boolean} filteredOnly - true to skip non-filtered records.
      */
     getById(id, filteredOnly) {}
 
     /**
-     * @param {(string[]|Object[])} fields - list of Fields or valid configuration for Fields
-     *      (A simple string representing the field name is sufficient for an entry).
+     * @param {Object} c - BaseStore configuration.
+     * @param {(string[]|Object[]|HoistField[])} c.fields - names or config objects for Fields.
      */
     constructor({fields}) {
         this.fields = fields.map(f => {
@@ -84,7 +89,7 @@ export class BaseStore {
      * Can apply basic validation and conversion (e.g. 'date' will convert from UTC time to
      * a JS Date object). An exception will be thrown if the validation or conversion fails.
      *
-     *  @param {Object} raw - json object containing raw data and 'id' property
+     * @param {Object} raw - json object containing raw data and 'id' property
      */
     createRecord(raw) {
         const ret = {id: raw.id, raw};

--- a/data/BaseStore.js
+++ b/data/BaseStore.js
@@ -19,11 +19,15 @@ export class BaseStore {
 
     /**
      * Fields contained in each record.
-     * @type {HoistField[]}
+     * @member {HoistField[]}
      */
     fields = null;
 
-    /** Get a specific field, by name. */
+    /**
+     * Get a specific field, by name.
+     * @param {string} name - field name to locate.
+     * @return {HoistField}
+     */
     getField(name) {
         return this.fields.find(it => it.name === name);
     }

--- a/data/Field.js
+++ b/data/Field.js
@@ -8,22 +8,24 @@
 import {startCase} from 'lodash';
 
 /**
- * Metadata for a column or 'field' in a Store record.
+ * Metadata for an individual data field within a Store record.
+ * @alias HoistField
  */
 export class Field {
 
-    name
-    type
-    label
-    defaultValue
+    name;
+    type;
+    label;
+    defaultValue;
 
     /**
-     * @param {string} name - unique key representing this field.
-     * @param {string} type - one of ['string', 'number', 'bool', 'json', 'date', 'day', 'auto']
+     * @param {Object} c - Field configuration.
+     * @param {string} c.name - unique key representing this field.
+     * @param {string} [c.type] - one of ['string', 'number', 'bool', 'json', 'date', 'day', 'auto']
      *      Default 'auto' indicates no conversion.
-     * @param {string} label - label for display
-     * @param {boolean} nullable - can this field contain null?
-     * @param {*} defaultValue - value to be used for records with a null, or non-existent value.
+     * @param {string} [c.label] - label for display, defaults to capitalized name.
+     * @param {boolean} [c.nullable] - true if field can contain null as a valid value.
+     * @param {*} [c.defaultValue] - value to be used for records with a null, or non-existent value.
      */
     constructor({
         name,

--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -26,10 +26,11 @@ export class LocalStore extends BaseStore {
     processRawData = null;
 
     /**
-     * @param {function} [processRawData] - Function to run on data presented to loadData() before
+     * @param {Object} c - LocalStore configuration.
+     * @param {function} [c.processRawData] - Function to run on data presented to loadData() before
      *      creating records.
-     * @param {function} [filter] - Filter function to be run on _allRecords to produce _records.
-     * @param {...*} [baseStoreArgs] - Additional properties to pass to BaseStore.
+     * @param {function} [c.filter] - Filter function to be run on _allRecords to produce _records.
+     * @param {...*} [c.baseStoreArgs] - Additional properties to pass to BaseStore.
      */
     constructor({processRawData = null, filter, ...baseStoreArgs}) {
         super(baseStoreArgs);

--- a/data/StoreSelectionModel.js
+++ b/data/StoreSelectionModel.js
@@ -46,9 +46,9 @@ export class StoreSelectionModel {
     }
 
     /**
-     * @param {Object} config
-     * @param {BaseStore} config.store - Store containing the data
-     * @param {string} [config.mode] - 'single' / 'multiple' / 'disabled'
+     * @param {Object} c - StoreSelectionModel configuration.
+     * @param {BaseStore} c.store - Store containing the data.
+     * @param {string} [c.mode] - one of ['single', 'multiple', 'disabled'].
      */
     constructor({store, mode = 'single'}) {
         this.store = store;

--- a/data/StoreSelectionModel.js
+++ b/data/StoreSelectionModel.js
@@ -46,8 +46,9 @@ export class StoreSelectionModel {
     }
 
     /**
-     * @param {BaseStore} store - Store containing the data
-     * @param {string} [mode] - 'single'/ 'multiple' / 'disabled'
+     * @param {Object} config
+     * @param {BaseStore} config.store - Store containing the data
+     * @param {string} [config.mode] - 'single' / 'multiple' / 'disabled'
      */
     constructor({store, mode = 'single'}) {
         this.store = store;

--- a/data/UrlStore.js
+++ b/data/UrlStore.js
@@ -10,18 +10,18 @@ import {XH} from '@xh/hoist/core';
 import {LocalStore} from './LocalStore';
 
 /**
- * A store with built-in support for loading data from a url.
+ * A store with built-in support for loading data from a URL.
  */
 export class UrlStore extends LocalStore {
 
-    url = '';
-    dataRoot = null;
+    url;
+    dataRoot;
 
     /**
      * @param {Object} c - UrlStore configuration.
      * @param {string} c.url - URL from which to load data.
-     * @param {string} [c.dataRoot] - Name of root node for records in returned data.
-     * @param {...*} [c.localStoreArgs] - Additional arguments to pass to LocalStore.
+     * @param {?string} [c.dataRoot] - Key of root node for records in returned data object.
+     * @param {...*} - Additional arguments to pass to LocalStore.
      */
     constructor({url, dataRoot = null, ...localStoreArgs}) {
         super(localStoreArgs);

--- a/data/UrlStore.js
+++ b/data/UrlStore.js
@@ -18,9 +18,10 @@ export class UrlStore extends LocalStore {
     dataRoot = null;
 
     /**
-     * @param {string} url
-     * @param {string} [dataRoot] - Name of root node for records in returned data
-     * @param {...*} [localStoreArgs] - Additional arguments to pass to LocalStore.
+     * @param {Object} c - UrlStore configuration.
+     * @param {string} c.url - URL from which to load data.
+     * @param {string} [c.dataRoot] - Name of root node for records in returned data.
+     * @param {...*} [c.localStoreArgs] - Additional arguments to pass to LocalStore.
      */
     constructor({url, dataRoot = null, ...localStoreArgs}) {
         super(localStoreArgs);

--- a/desktop/cmp/chart/ChartModel.js
+++ b/desktop/cmp/chart/ChartModel.js
@@ -18,11 +18,10 @@ export class ChartModel {
     @observable.ref series = [];
 
     /**
-     * @param opts
-     * @param {Object} opts.config - Highcharts configuration object for the managed chart.
-     *      This may includes all native highcharts options other than 'series',
-     *      which should be set on the separate 'series' property on this object.
-     * @param {Array} opts.series - Data series to be displayed.
+     * @param {Object} c - ChartModel configuration.
+     * @param {Object} c.config - Highcharts configuration object for the managed chart. May include
+     *      any Highcharts opts other than `series`, which should be set via dedicated config.
+     * @param {Object[]} c.series - Data series to be displayed.
      */
     constructor({config, series = []} = {}) {
         this.config = config;

--- a/desktop/cmp/contextmenu/ContextMenuItem.js
+++ b/desktop/cmp/contextmenu/ContextMenuItem.js
@@ -10,7 +10,8 @@ import {Icon} from '@xh/hoist/icon';
 import {assign} from 'lodash';
 
 /**
- *  Basic Model Object for ContextMenu.
+ *  Basic Model for an item displayed within a generic ContextMenu.
+ *  @see StoreContextMenuItem for a more specific (and common) implementation tied to data views.
  */
 export class ContextMenuItem {
 
@@ -20,18 +21,15 @@ export class ContextMenuItem {
     items;
     disabled;
     hidden;
-    prepareFn;
 
     /**
-     * @param {string} text - label to be displayed.
-     * @param {Object} [icon] - optional icon to be displayed.
-     * @param {function} [action] - Executed when the user clicks the menuitem.
-     * @param {Object[]} [items] - child menu items.
-     * @param {boolean} [disabled] - true to disable this item.
-     * @param {boolean} [hidden] - true to hide this item.
-     * @param {function} [prepareFn] - function of the form (item, record, selection) => {}
-     *      The prepareFn is a callback that is triggered before each time the menuitem is shown.
-     *      It can be used to modify the menuitem based on the record / selection.
+     * @param {Object} c - ContextMenuItem configuration.
+     * @param {string} c.text - label to be displayed.
+     * @param {Object} [c.icon] - icon to be displayed.
+     * @param {function} [c.action] - Executed when the user clicks the menuitem.
+     * @param {Object[]} [c.items] - child menu items.
+     * @param {boolean} [c.disabled] - true to disable this item.
+     * @param {boolean} [c.hidden] - true to hide this item.
      */
     constructor({
         text,
@@ -40,7 +38,6 @@ export class ContextMenuItem {
         items = null,
         disabled = false,
         hidden = false,
-        prepareFn = null
     }) {
         this.text = text;
         this.icon = icon;
@@ -48,7 +45,6 @@ export class ContextMenuItem {
         this.items = items;
         this.disabled = disabled;
         this.hidden = hidden;
-        this.prepareFn = prepareFn;
     }
 
     /**

--- a/desktop/cmp/contextmenu/ContextMenuItem.js
+++ b/desktop/cmp/contextmenu/ContextMenuItem.js
@@ -37,7 +37,7 @@ export class ContextMenuItem {
         action = null,
         items = null,
         disabled = false,
-        hidden = false,
+        hidden = false
     }) {
         this.text = text;
         this.icon = icon;

--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -10,7 +10,8 @@ import {StoreContextMenuItem} from './StoreContextMenuItem';
 import {Icon} from '@xh/hoist/icon';
 
 /**
- * Model for ContextMenu on stores.
+ * Model for ContextMenus interacting with data provided by Hoist data stores, typically via a Grid.
+ * @see GridModel.contextMenuFn
  */
 export class StoreContextMenu {
 
@@ -18,18 +19,22 @@ export class StoreContextMenu {
     gridModel = null;
 
     /**
-     * @param {Object[]} items - collection of StoreContextMenuItems, configs to create them, or Strings.
-     *      If a String, value can be '-' for a separator, a hoist token, or a token for a native AG Grid menu item.
+     * @param {Object} c - StoreContextMenu configuration.
+     * @param {Object[]} c.items - StoreContextMenuItems or configs / strings to create.
      *
-     *      Hoist tokens are:
-     *          'colChooser' - Provides a column chooser for a grid, requires a gridModel
-     *          'exportExcel' - Export the grid to excel, requires a gridModel
-     *          'exportCsv' - Export the grid to csv, requires a gridModel
+     *      If a String, value can be '-' for a separator, a Hoist token (below),
+     *      or a token supported by ag-Grid for its native menu items.
+     *      @see {@link https://www.ag-grid.com/javascript-grid-context-menu/#built-in-menu-items|ag-Grid Docs}
      *
-     *      Note: to get an AG Grid native 'export' menu, use token 'exportLocal'. This is to avoid conflicting with the Hoist
-     *      server-side export tokens.
+     *      Hoist tokens, all of which require a GridModel:
+     *          `colChooser` - display column chooser for a grid.
+     *          `export` - export grid data to excel via Hoist's server-side export capabilities.
+     *          `exportExcel` - same as above.
+     *          `exportCsv` - export grid data to CSV via Hoist's server-side export capabilities.
+     *          `exportLocal` - export grid data to Excel via ag-Grid's built-in client side export.
      *
-     * @param {Object} [gridModel] - an optional gridModel to bind to this contextMenu, used to control implementation of menu items
+     * @param {GridModel} [c.gridModel] - GridModel to bind to this contextMenu, used to enable
+     *      implementation of menu items / tokens above.
      */
     constructor({items, gridModel}) {
         this.gridModel = gridModel;

--- a/desktop/cmp/contextmenu/StoreContextMenuItem.js
+++ b/desktop/cmp/contextmenu/StoreContextMenuItem.js
@@ -5,9 +5,6 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-/**
- *  Basic Model Object for ContextMenu for Stores.
- */
 export class StoreContextMenuItem {
 
     text;
@@ -20,17 +17,16 @@ export class StoreContextMenuItem {
     recordsRequired;
 
     /**
-     * @param {string} text - label to be displayed.
-     * @param {Object} icon - optional icon to be displayed.
-     * @param {Object[]} items - child menu items.
-     * @param {function} action - function of the form (item, record, selection) => {}
-     *      Executed when the user clicks the menuitem.
-     * @param {boolean} disabled - true to disable this item.
-     * @param {boolean} hidden - true to hide this item.
-     * @param {function} prepareFn - function of the form (item, record, selection) => {}
-     *      The prepareFn is a callback that is triggered before each time the menuitem is shown.
-     *      It can be used to modify the menuitem based on the record / selection.
-     * @param {(number|boolean)} recordsRequired - how many records must be 'active'
+     * @param {Object} c - StoreContextMenuItem configuration.
+     * @param {string} c.text - label to be displayed.
+     * @param {Object} [c.icon] - icon to be displayed.
+     * @param {Object[]} [c.items] - child menu items.
+     * @param {storeCtxMenuItemActionFn} [c.action] - called on store context menu item click.
+     * @param {boolean} [c.disabled] - true to disable this item.
+     * @param {boolean} [c.hidden] - true to hide this item.
+     * @param {storeCtxMenuItemPrepFn} [c.prepareFn] - called prior to context menu item show,
+     *      available to modify the item based on current record / selection at time of show.
+     * @param {(number|boolean)} [c.recordsRequired] - how many records must be 'active'
      *      (selected and / or clicked upon) for the menuitem to be enabled.
      *      int: specifies exactly n number of records. Defaults to 1 for single record actions.
      *          Can specify 0 to only enable menuitem if no records are active.
@@ -57,3 +53,18 @@ export class StoreContextMenuItem {
         this.recordsRequired = recordsRequired;
     }
 }
+
+/**
+ * @callback storeCtxMenuItemActionFn - called on store context menu item click.
+ * @param {ContextMenuItem} item - the menu item itself.
+ * @param {Object} [record] - row data object (entire row, if any).
+ * @param {Object[]} [selection] - all currently selected records (if any).
+ */
+
+/**
+ * @callback storeCtxMenuItemPrepFn - called prior to store context menu item show, available to
+ *      modify the item based on current record / selection at time of show.
+ * @param {ContextMenuItem} item - the menu item itself.
+ * @param {Object} [record] - row data object (entire row, if any).
+ * @param {Object[]} [selection] - all currently selected records (if any).
+ */

--- a/desktop/cmp/contextmenu/StoreContextMenuItem.js
+++ b/desktop/cmp/contextmenu/StoreContextMenuItem.js
@@ -21,10 +21,10 @@ export class StoreContextMenuItem {
      * @param {string} c.text - label to be displayed.
      * @param {Object} [c.icon] - icon to be displayed.
      * @param {Object[]} [c.items] - child menu items.
-     * @param {storeCtxMenuItemActionFn} [c.action] - called on store context menu item click.
+     * @param {ActionCb} [c.action] - called on store context menu item click.
      * @param {boolean} [c.disabled] - true to disable this item.
      * @param {boolean} [c.hidden] - true to hide this item.
-     * @param {storeCtxMenuItemPrepFn} [c.prepareFn] - called prior to context menu item show,
+     * @param {PrepareFnCb} [c.prepareFn] - called prior to context menu item show,
      *      available to modify the item based on current record / selection at time of show.
      * @param {(number|boolean)} [c.recordsRequired] - how many records must be 'active'
      *      (selected and / or clicked upon) for the menuitem to be enabled.
@@ -55,15 +55,15 @@ export class StoreContextMenuItem {
 }
 
 /**
- * @callback storeCtxMenuItemActionFn - called on store context menu item click.
+ * @callback ActionCb - called on store context menu item click.
  * @param {ContextMenuItem} item - the menu item itself.
  * @param {Object} [record] - row data object (entire row, if any).
  * @param {Object[]} [selection] - all currently selected records (if any).
  */
 
 /**
- * @callback storeCtxMenuItemPrepFn - called prior to store context menu item show, available to
- *      modify the item based on current record / selection at time of show.
+ * @callback PrepareFnCb - called prior to store context menu item show, available to modify the
+ *      item based on current record / selection at time of show.
  * @param {ContextMenuItem} item - the menu item itself.
  * @param {Object} [record] - row data object (entire row, if any).
  * @param {Object[]} [selection] - all currently selected records (if any).

--- a/desktop/cmp/dataview/DataView.js
+++ b/desktop/cmp/dataview/DataView.js
@@ -12,7 +12,7 @@ import {GridModel} from '@xh/hoist/desktop/cmp/grid';
 
 /**
  * A DataView is a specialized version of the Grid component. It displays its data within a
- * single column, using a defined component for rendering each item.
+ * single column, using a configured component for rendering each item.
  *
  * @see DataViewModel
  */

--- a/desktop/cmp/dataview/DataView.js
+++ b/desktop/cmp/dataview/DataView.js
@@ -10,6 +10,12 @@ import {XH, HoistComponent, elemFactory, LayoutSupport} from '@xh/hoist/core';
 import {grid} from '@xh/hoist/desktop/cmp/grid';
 import {GridModel} from '@xh/hoist/desktop/cmp/grid';
 
+/**
+ * A DataView is a specialized version of the Grid component. It displays its data within a
+ * single column, using a defined component for rendering each item.
+ *
+ * @see DataViewModel
+ */
 @HoistComponent()
 @LayoutSupport
 export class DataView extends Component {

--- a/desktop/cmp/dataview/DataViewModel.js
+++ b/desktop/cmp/dataview/DataViewModel.js
@@ -12,7 +12,7 @@ import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
 
 /**
  * DataViewModel is a wrapper around GridModel, which shows sorted data in a single column,
- * using a defined component for rendering each item.
+ * using a configured component for rendering each item.
  *
  * This is the primary application entry-point for specifying DataView component options and behavior.
  */
@@ -41,7 +41,7 @@ export class DataViewModel {
      *      Will receive record via its props.
      * @param {BaseStore} c.store - store containing the data to be displayed.
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
-     *      config or string `mode` with which to create one.
+     *      config or string `mode` from which to create.
      * @param {string} [c.emptyText] - text/HTML to display if view has no records.
      * @param {function} [c.contextMenuFn] - closure returning a StoreContextMenu().
      */

--- a/desktop/cmp/dataview/DataViewModel.js
+++ b/desktop/cmp/dataview/DataViewModel.js
@@ -11,8 +11,10 @@ import {StoreSelectionModel} from '@xh/hoist/data';
 import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
 
 /**
- * DataViewModel is a wrapper around GridModel, which shows sorted data in
- * a single column, using a defined component for rendering each item.
+ * DataViewModel is a wrapper around GridModel, which shows sorted data in a single column,
+ * using a defined component for rendering each item.
+ *
+ * This is the primary application entry-point for specifying DataView component options and behavior.
  */
 @HoistModel()
 export class DataViewModel {
@@ -34,13 +36,14 @@ export class DataViewModel {
     };
 
     /**
-     * @param {function} itemFactory - elemFactory for the component used to render each item.
+     * @param {Object} c - DataViewModel configuration.
+     * @param {function} c.itemFactory - elemFactory for the component used to render each item.
      *      Will receive record via its props.
-     * @param {BaseStore} store - store containing the data for the dataview.
-     * @param {(StoreSelectionModel|Object|String)} [selModel] - selection model to use,
-     *      config to create one, or 'mode' property for a selection model.
-     * @param {string} [emptyText] - empty text to display if DataView has no records. Can be valid HTML.
-     * @param {function} [contextMenuFn] - closure returning a StoreContextMenu().
+     * @param {BaseStore} c.store - store containing the data to be displayed.
+     * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
+     *      config or string `mode` with which to create one.
+     * @param {string} [c.emptyText] - text/HTML to display if view has no records.
+     * @param {function} [c.contextMenuFn] - closure returning a StoreContextMenu().
      */
     constructor({
         itemFactory,
@@ -86,7 +89,6 @@ export class DataViewModel {
         return this.selModel.singleRecord;
     }
 
-    
     /** Load the underlying store. */
     loadAsync(...args) {
         return this.store.loadAsync(...args);
@@ -97,9 +99,10 @@ export class DataViewModel {
         return this.store.loadData(...args);
     }
 
-    //---------------------------------
+
+    //------------------------
     // Implementation
-    //---------------------------------
+    //------------------------
     parseSelModel(selModel, store) {
         if (selModel instanceof StoreSelectionModel) {
             return selModel;

--- a/desktop/cmp/form/JsonField.js
+++ b/desktop/cmp/form/JsonField.js
@@ -26,7 +26,7 @@ import 'codemirror/addon/lint/lint.js';
 import './JsonField.css';
 
 /**
- * A JSON Editor
+ * A field for editing and validating JSON, providing a mini-IDE style editor powered by CodeMirror.
  */
 @HoistComponent()
 export class JsonField extends HoistField {
@@ -43,7 +43,7 @@ export class JsonField extends HoistField {
         height: PT.number,
         /**
          * Configuration object with any properties supported by the CodeMirror api.
-         * @see https://codemirror.net/doc/manual.html#api_configuration for details.
+         * @see {@link https://codemirror.net/doc/manual.html#api_configuration|CodeMirror Docs}
          */
         editorProps: PT.object
     };

--- a/desktop/cmp/grid/ColChooser.js
+++ b/desktop/cmp/grid/ColChooser.js
@@ -13,6 +13,19 @@ import {leftRightChooser, leftRightChooserFilter} from '@xh/hoist/desktop/cmp/le
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 
+/**
+ * Hoist UI for user selection and discovery of available Grid columns, enabled via the
+ * GridModel.enableColChooser config option.
+ *
+ * This component displays both available and currently visible columns in two left/right
+ * grids, allowing users to toggle columns on and off within its associated grid.
+ *
+ * It derives its configuration primary from the Grid's Column definitions, supporting features such
+ * as custom column display names and descriptions, grouped display of the available column library,
+ * and a quick filter for long lists.
+ *
+ * It is not necessary to manually create instances of this component within an application.
+ */
 @HoistComponent()
 export class ColChooser extends Component {
 

--- a/desktop/cmp/grid/ColChooserButton.js
+++ b/desktop/cmp/grid/ColChooserButton.js
@@ -10,11 +10,18 @@ import {HoistComponent, elemFactory} from '@xh/hoist/core';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 
+/**
+ * A convenience button to trigger the display of a ColChooser for user selection and discovery of
+ * available Grid columns. For use by applications when a button is desired in addition to the
+ * context menu item built into the Grid component directly.
+ *
+ * Requires the `GridModel.enableColChooser` config option to be true.
+ */
 @HoistComponent()
 export class ColChooserButton extends Component {
 
     static propTypes = {
-        /** Grid model of the grid for which this button should show a chooser. */
+        /** GridModel of the grid for which this button should show a chooser. */
         gridModel: PT.object
     };
 

--- a/desktop/cmp/grid/ColChooserModel.js
+++ b/desktop/cmp/grid/ColChooserModel.js
@@ -22,6 +22,9 @@ export class ColChooserModel {
 
     @observable isOpen = false;
 
+    /**
+     * @param {GridModel} gridModel - model for the grid to be managed.
+     */
     constructor(gridModel) {
         this.gridModel = gridModel;
         this.lrModel = new LeftRightChooserModel({

--- a/desktop/cmp/grid/ColChooserModel.js
+++ b/desktop/cmp/grid/ColChooserModel.js
@@ -8,6 +8,12 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {action, observable} from '@xh/hoist/mobx';
 import {LeftRightChooserModel} from '@xh/hoist/desktop/cmp/leftrightchooser';
 
+/**
+ * State management for the ColChooser component.
+ *
+ * It is not necessary to manually create instances of this class within an application.
+ * @private
+ */
 @HoistModel()
 export class ColChooserModel {
 

--- a/desktop/cmp/grid/ExportManager.js
+++ b/desktop/cmp/grid/ExportManager.js
@@ -14,8 +14,8 @@ import {orderBy, uniq, isString, isFunction} from 'lodash';
 import download from 'downloadjs';
 
 /**
- * Exports Grid data to either Excel or CSV via using Hoist's server-side export.
- * @see HoistColumn constructor API for options to control exported values and formats.
+ * Exports Grid data to either Excel or CSV via Hoist's server-side export capabilities.
+ * @see HoistColumn API for options to control exported values and formats.
  *
  * It is not necessary to manually create instances of this class within an application.
  * @private
@@ -23,7 +23,7 @@ import download from 'downloadjs';
 export class ExportManager {
 
     /**
-     * Export a GridModel to a file. Called via `GridModel.export()`.
+     * Export a GridModel to a file. Typically called via `GridModel.export()`.
      *
      * @param {GridModel} gridModel - GridModel to export.
      * @param {(string|function)} filename - name for exported file or closure to generate.
@@ -73,6 +73,7 @@ export class ExportManager {
         download(blob, filename);
         XH.toast({message: 'Export complete', intent: 'success'});
     }
+
 
     //-----------------------
     // Implementation

--- a/desktop/cmp/grid/ExportManager.js
+++ b/desktop/cmp/grid/ExportManager.js
@@ -14,21 +14,16 @@ import {orderBy, uniq, isString, isFunction} from 'lodash';
 import download from 'downloadjs';
 
 /**
- * Exports a grid to either Excel or CSV, using Hoist's server-side export.
+ * Exports Grid data to either Excel or CSV via using Hoist's server-side export.
+ * @see HoistColumn constructor API for options to control exported values and formats.
  *
- * Columns support the following properties on their definitions to manage how they are exported:
- *      {string} exportName - custom header for exported grid column.
- *      {(string|function)} exportValue - modifies the value used in export:
- *              If string, can be used to point to a different field on the record.
- *              If function, can be used to transform the value.
- *      {string} exportFormat - Excel export format pattern.
- *              @see ExportFormat for available constants.
+ * It is not necessary to manually create instances of this class within an application.
+ * @private
  */
 export class ExportManager {
 
     /**
-     * Export a GridModel to a file. Typically not called directly, but via the `export` convenience
-     * method on GridModel.
+     * Export a GridModel to a file. Called via `GridModel.export()`.
      *
      * @param {GridModel} gridModel - GridModel to export.
      * @param {(string|function)} filename - name for exported file or closure to generate.

--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -16,15 +16,16 @@ import {agGridReact, navigateSelection} from './ag-grid';
 import {colChooser} from './ColChooser';
 
 /**
- * Grid Component
+ * The primary rich data grid component within the Hoist desktop toolkit.
+ * It is a highly managed wrapper around AG-Grid, and is the main display component for GridModel.
  *
- * This is the main view component for a Hoist Grid.  It is a highly managed
- * wrapper around AG Grid, and is the main display component for GridModel.
+ * Applications should typically configure and interact with Grids via a GridModel, which provides
+ * support for specifying the Grid's data Store, Column definitions, sorting and grouping state,
+ * selection API, and more.
  *
- * Applications should typically create and manipulate a GridModel for most purposes,
- * including specifying columns and rows, sorting and grouping, and interacting with
- * the selection. Use this class to control the AG Grid UI options and specific
- * behavior of the grid.
+ * Use this class to control the AG-Grid UI options and specific behavior of the grid.
+ * @see {@link https://www.ag-grid.com/javascript-grid-reference-overview/|AG-Grid Docs}
+ * @see GridModel
  */
 @HoistComponent()
 @LayoutSupport
@@ -32,7 +33,7 @@ export class Grid extends Component {
 
     _scrollOnSelect = true;
 
-    // Trackable stamp incremented everytime the agGrid receives a new set of data.
+    // Trackable stamp incremented every time the agGrid receives a new set of data.
     @observable _dataVersion = 0;
 
     static propTypes = {

--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -17,14 +17,14 @@ import {colChooser} from './ColChooser';
 
 /**
  * The primary rich data grid component within the Hoist desktop toolkit.
- * It is a highly managed wrapper around AG-Grid, and is the main display component for GridModel.
+ * It is a highly managed wrapper around ag-Grid and is the main display component for GridModel.
  *
  * Applications should typically configure and interact with Grids via a GridModel, which provides
  * support for specifying the Grid's data Store, Column definitions, sorting and grouping state,
  * selection API, and more.
  *
- * Use this class to control the AG-Grid UI options and specific behavior of the grid.
- * @see {@link https://www.ag-grid.com/javascript-grid-reference-overview/|AG-Grid Docs}
+ * Use this Component's props to control the ag-Grid-specific UI options and handlers.
+ * @see {@link https://www.ag-grid.com/javascript-grid-reference-overview/|ag-Grid Docs}
  * @see GridModel
  */
 @HoistComponent()
@@ -33,7 +33,8 @@ export class Grid extends Component {
 
     _scrollOnSelect = true;
 
-    // Trackable stamp incremented every time the agGrid receives a new set of data.
+    // Observable stamp incremented every time the ag-Grid receives a new set of data.
+    // Used to ensure proper re-running / sequencing of data and selection reactions.
     @observable _dataVersion = 0;
 
     static propTypes = {
@@ -41,16 +42,16 @@ export class Grid extends Component {
         /**
          * Options for AG Grid's API.
          *
-         * This constitutes an 'escape hatch' for applications that need to get to the
-         * underlying AG Grid API.  It should be used with care and at the application
-         * developers risk.  Settings made here may interfere with the operation of this
-         * component and its use of the AG Grid API.
+         * This constitutes an 'escape hatch' for applications that need to get to the underlying
+         * ag-Grid API.  It should be used with care. Settings made here might be overwritten and/or
+         * interfere with the implementation of this component and its use of the ag-Grid API.
          */
         agOptions: PT.object,
 
         /**
          * Callback to call when a row is double clicked.  Function will receive an event
          * with a data node containing the row's data.
+         * @see {@link https://www.ag-grid.com/javascript-grid-events/#properties-and-hierarchy|ag-Grid Event Docs}
          */
         onRowDoubleClicked: PT.func
     };

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -86,16 +86,17 @@ export class GridModel {
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` with which to create one.
      * @param {(Object|string)} [c.stateModel] - config or string `gridId` for a GridStateModel.
-     * @param {string} [c.emptyText] - text/HTML to display if grid has no records.
+     * @param {?string} [c.emptyText] - text/HTML to display if grid has no records.
      *      Defaults to null, in which case no empty text will be shown.
      * @param {(GridSorter|GridSorter[])} [c.sortBy] - column(s) and direction for sorting.
-     * @param {string} [c.groupBy] - Column ID by which to group.
+     * @param {?string} [c.groupBy] - Column ID by which to do full-width row grouping.
      * @param {boolean} [c.enableColChooser] - true to setup support for column chooser UI and
      *      install a default context menu item to launch the chooser.
      * @param {boolean} [c.enableExport] - true to install default export context menu items.
      * @param {(function|string)} [c.exportFilename] - filename for exported file,
      *      or a closure to generate one.
-     * @param {function} [c.contextMenuFn] - closure returning a StoreContextMenu().
+     * @param {function} [c.contextMenuFn] - closure returning a StoreContextMenu.
+     *      @see StoreContextMenu
      */
     constructor({
         store,
@@ -131,7 +132,7 @@ export class GridModel {
     }
 
     /**
-     * Exports the grid using Hoist's server-side export.
+     * Export grid data using Hoist's server-side export.
      *
      * @param {Object} options
      * @param {string} options.type - type of export - one of ['excel', 'excelTable', 'csv'].
@@ -143,7 +144,7 @@ export class GridModel {
     }
 
     /**
-     * Exports the grid using agGrid's client-side export
+     * Export grid data using ag-Grid's built-in client-side export.
      *
      * @param {string} filename - name for exported file.
      * @param {string} type - type of export - one of ['excel', 'csv'].
@@ -344,7 +345,7 @@ export class GridModel {
         if (isPlainObject(stateModel)) {
             ret = new GridStateModel(stateModel);
         } else if (isString(stateModel)) {
-            ret = new GridStateModel({id: stateModel});
+            ret = new GridStateModel({gridId: stateModel});
         }
         if (ret) ret.init(this);
 
@@ -359,5 +360,5 @@ export class GridModel {
 /**
  * @typedef {Object} GridSorter - config for GridModel sorting.
  * @property {string} colId - Column ID on which to sort.
- * @property {string} [sort] - direction to sort - [asc|desc] - default asc.
+ * @property {string} [sort] - direction to sort - either ['asc', 'desc'] - default asc.
  */

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -46,16 +46,19 @@ export class GridModel {
     stateModel = null;
     /** @member {ColChooserModel} */
     colChooserModel = null;
+    /** @member {function} */
     contextMenuFn = null;
-    exportFilename = null;
-    enableExport = null;
+    /** @member {boolean} */
+    enableExport = false;
+    /** @member {string} */
+    exportFilename = 'export';
 
     //------------------------
     // Observable API
     //------------------------
     /** @member {Column[]} */
     @observable.ref columns = [];
-    /** @member {GridSorter[]} */
+    /** @member {GridSorterDef[]} */
     @observable.ref sortBy = [];
     /** @member {?string} */
     @observable groupBy = null;
@@ -88,7 +91,8 @@ export class GridModel {
      * @param {(Object|string)} [c.stateModel] - config or string `gridId` for a GridStateModel.
      * @param {?string} [c.emptyText] - text/HTML to display if grid has no records.
      *      Defaults to null, in which case no empty text will be shown.
-     * @param {(GridSorter|GridSorter[])} [c.sortBy] - column(s) and direction for sorting.
+     * @param {(string|string[]|GridSorterDef|GridSorterDef[])} [c.sortBy] - colId(s) or sorter
+     *      config(s) with colId and sort direction.
      * @param {?string} [c.groupBy] - Column ID by which to do full-width row grouping.
      * @param {boolean} [c.enableColChooser] - true to setup support for column chooser UI and
      *      install a default context menu item to launch the chooser.
@@ -161,9 +165,7 @@ export class GridModel {
         }
     }
 
-    /**
-     * Select the first row in the grid.
-     */
+    /** Select the first row in the grid. */
     selectFirst() {
         const {store, selModel, sortBy} = this,
             colIds = sortBy.map(it => it.colId),
@@ -180,7 +182,6 @@ export class GridModel {
 
     /**
      * Shortcut to the currently selected records (observable).
-     *
      * @see StoreSelectionModel.records
      */
     get selection() {
@@ -189,8 +190,7 @@ export class GridModel {
 
     /**
      * Shortcut to a single selected record (observable).
-     * This will be null if multiple records are selected.
-     *
+     * Null if multiple records are selected.
      * @see StoreSelectionModel.singleRecord
      */
     get selectedRecord() {
@@ -230,7 +230,8 @@ export class GridModel {
 
     /**
      * This method is no-op if provided any sorters without a corresponding column.
-     * @param {(GridSorter|GridSorter[])} sorters - column(s) and direction for sorting.
+     * @param {(string|string[]|GridSorterDef|GridSorterDef[])} sorters - colId(s) or sorter
+     *      config(s) with colId and sort direction.
      */
     @action
     setSortBy(sorters) {
@@ -248,7 +249,6 @@ export class GridModel {
         this.sortBy = sorters;
     }
 
-
     /** Load the underlying store. */
     loadAsync(...args) {
         return this.store.loadAsync(...args);
@@ -259,11 +259,12 @@ export class GridModel {
         return this.store.loadData(...args);
     }
 
-    // TODO - review options for a "true" clone here, and behavior of setColumns() below.
+    /** @return {Column[]} */
     cloneColumns() {
         return [...this.columns];
     }
 
+    /** @param {Column[]} cols */
     @action
     setColumns(cols) {
         this.columns = [...cols];
@@ -358,7 +359,7 @@ export class GridModel {
 }
 
 /**
- * @typedef {Object} GridSorter - config for GridModel sorting.
+ * @typedef {Object} GridSorterDef - config for GridModel sorting.
  * @property {string} colId - Column ID on which to sort.
  * @property {string} [sort] - direction to sort - either ['asc', 'desc'] - default asc.
  */

--- a/desktop/cmp/grid/GridStateModel.js
+++ b/desktop/cmp/grid/GridStateModel.js
@@ -8,26 +8,41 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {cloneDeep, debounce, find} from 'lodash';
 import {start} from '@xh/hoist/promise';
 
+/**
+ * Model for serializing/de-serializing saved grid state across user browsing sessions
+ * and applying saved state to its parent GridModel upon that model's construction.
+ *
+ * GridModels can enable persistent grid state via their stateModel config, typically
+ * provided as a simple string gridId to identify a given grid instance.
+ *
+ * It is not necessary to manually create instances of this class within an application.
+ * @private
+ */
 @HoistModel()
 export class GridStateModel {
 
-    // Version of grid state.  Increment *only* when we need to abandon all existing grid state in the wild.
-    static gridStateVersion = 1;
+    /**
+     * Version of grid state definitions currently supported by this model.
+     * Increment *only* when we need to abandon all existing grid state that might be saved on
+     * user workstations to ensure compatibility with a new serialization or approach.
+     */
+    static GRID_STATE_VERSION = 1;
 
     gridModel = null;
-    xhStateId = null;
+    gridId = null;
 
     state = {};
     defaultState = null;
 
     /**
-     * @param {object} config
-     * @param {string} config.xhStateId - Unique grid identifier.
-     * @param {boolean} [config.trackColumns] - Set to true to save state of columns (including ordering, and widths).
-     * @param {boolean} [config.trackSort] - Set to true to save sorting.
+     * @param {Object} c - GridStateModel configuration.
+     * @param {string} c.gridId - unique identifier for a Grid instance.
+     * @param {boolean} [c.trackColumns] - true to save state of columns,
+     *      including visibility, ordering and pixel widths.
+     * @param {boolean} [c.trackSort] - true to save sorting.
      */
-    constructor({xhStateId, trackColumns = true, trackSort = true}) {
-        this.xhStateId = xhStateId;
+    constructor({gridId, trackColumns = true, trackSort = true}) {
+        this.gridId = gridId;
         this.trackColumns = trackColumns;
         this.trackSort = trackSort;
     }
@@ -47,7 +62,7 @@ export class GridStateModel {
     }
 
     getStateKey() {
-        return `gridState.v${GridStateModel.gridStateVersion}.${this.xhStateId}`;
+        return `gridState.v${GridStateModel.GRID_STATE_VERSION}.${this.gridId}`;
     }
 
     readState(stateKey) {

--- a/desktop/cmp/grid/GridStateModel.js
+++ b/desktop/cmp/grid/GridStateModel.js
@@ -13,7 +13,7 @@ import {start} from '@xh/hoist/promise';
  * and applying saved state to its parent GridModel upon that model's construction.
  *
  * GridModels can enable persistent grid state via their stateModel config, typically
- * provided as a simple string gridId to identify a given grid instance.
+ * provided as a simple string `gridId` to identify a given grid instance.
  *
  * It is not necessary to manually create instances of this class within an application.
  * @private
@@ -27,6 +27,7 @@ export class GridStateModel {
      * user workstations to ensure compatibility with a new serialization or approach.
      */
     static GRID_STATE_VERSION = 1;
+    static STATE_SAVE_DEBOUNCE_MS = 500;
 
     gridModel = null;
     gridId = null;
@@ -140,7 +141,8 @@ export class GridStateModel {
 
         if (!state.columns) return;
 
-        // Match columns in state to columns in code, apply stateful properties, and add to new columns in stateful order.
+        // Match columns in state to model columns via colId, apply stateful properties,
+        // then add to new columns in stateful order.
         state.columns.forEach(colState => {
             const col = find(cols, {colId: colState.colId});
             if (!col) return; // Do not attempt to include stale column state.
@@ -186,5 +188,5 @@ export class GridStateModel {
     //--------------------------
     saveStateChange = debounce(() => {
         this.saveState(this.getStateKey(), this.state);
-    }, 500);
+    }, GridStateModel.STATE_SAVE_DEBOUNCE_MS);
 }

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
@@ -16,18 +16,18 @@ import {convertIconToSvg, Icon} from '@xh/hoist/icon';
 @HoistModel()
 export class LeftRightChooserModel {
     /**
-     * Grid Model for the left-hand side
+     * Grid Model for the left-hand side.
      * @type GridModel
      */
     leftModel = null;
 
     /**
-     * Grid Model for the right-hand side
+     * Grid Model for the right-hand side.
      * @type GridModel
      */
     rightModel = null;
 
-    /** Property to enable/disable the description panel */
+    /** True to enable the description panel. */
     hasDescription = null;
 
     _lastSelectedSide = null;
@@ -45,8 +45,7 @@ export class LeftRightChooserModel {
      * to include unfiltered records.
      *
      * @see LeftRightChooserFilter - a component to easily control this field.
-     *
-     * @param {function} fn
+     * @param {function} fn - predicate function for filtering.
      */
     setDisplayFilter(fn) {
         this.leftModel.store.setFilter(fn);
@@ -66,24 +65,19 @@ export class LeftRightChooserModel {
     }
 
     /**
-     * @param {Object[]} data - source for both lists, with each item containing the properties below.
-     * @param {string} data[].text - primary label for the item.
-     * @param {string} data[].value - value that the item represents.
-     * @param {string} data[].description - user-friendly, longer description of the item.
-     * @param {string} data[].group - grid group in which to show the item.
-     * @param {string} data[].side - initial side of the item.
-     * @param {boolean} data[].locked - true to prevent the user from moving the item between sides.
-     * @param {boolean} data[].exclude - true to exclude the item from the chooser entirely.
-     *
-     * @param {string} ungroupedName - placeholder group value when an item has no group.
-     * @param {string} leftTitle - title of the left-side list.
-     * @param {boolean} leftGroupingEnabled - true to enable grouping on the the left-side list.
-     * @param {boolean} leftGroupingExpanded - true to override default one level group expansion on left grid
-     * @param {Object[]} leftSortBy - one or more sorters to apply to the left-side store.
-     * @param {string} rightTitle - title of the right-side list.
-     * @param {boolean} rightGroupingEnabled - true to enable grouping on the the right-side list.
-     * @param {boolean} rightGroupingExpanded - true to override default one level group expansion on right grid
-     * @param {Object[]} rightSortBy - one or more sorters to apply to the right-side store.
+     * @param {Object} c - LeftRightChooserModel configuration.
+     * @param {LeftRightChooserItem[]} c.data - source data for both lists, split by `side' property.
+     * @param {string} [c.ungroupedName] - placeholder group value when an item has no group.
+     * @param {?string} [c.leftTitle] - title of the left-side list.
+     * @param {boolean} [c.leftGroupingEnabled] - true to enable grouping on the the left-side list.
+     * @param {boolean} [c.leftGroupingExpanded] - default true, false to show a grouped left-side
+     *      list with all groups initially collapsed.
+     * @param {(GridSorter|GridSorter[])} [c.leftSortBy] - sorter(s) to apply to the left-side store.
+     * @param {?string} [c.rightTitle] - title of the right-side list.
+     * @param {boolean} [c.rightGroupingEnabled] - true to enable grouping on the the right-side list.
+     * @param {boolean} [c.rightGroupingExpanded] - default true, false to show a grouped right-side
+     *      list with all groups initially collapsed.
+     * @param {(GridSorter|GridSorter[])} [c.rightSortBy] - sorter(s) to apply to the right-side store.
      */
     constructor({
         data = [],
@@ -105,9 +99,23 @@ export class LeftRightChooserModel {
 
         const fields = ['text', 'value', 'description', 'group', 'side', 'locked', 'exclude'];
 
-        const leftTextCol = {field: 'text', flex: true,  headerName: leftTitle, renderer: this.getTextColRenderer('left')},
-            rightTextCol = {field: 'text', flex: true,  headerName: rightTitle, renderer: this.getTextColRenderer('right')},
-            groupCol = {field: 'group', headerName: 'Group', hide: true};
+        const leftTextCol = {
+                field: 'text',
+                flex: true,
+                headerName: leftTitle,
+                renderer: this.getTextColRenderer('left')
+            },
+            rightTextCol = {
+                field: 'text',
+                flex: true,
+                headerName: rightTitle,
+                renderer: this.getTextColRenderer('right')
+            },
+            groupCol = {
+                field: 'group',
+                headerName: 'Group',
+                hide: true
+            };
 
         this.leftModel = new GridModel({
             store: new LocalStore({fields}),
@@ -153,7 +161,7 @@ export class LeftRightChooserModel {
             return `
                 <div class='xh-lr-chooser__item-row ${groupClass}'>
                     ${v} ${data.locked ? lockSvg : ''}
-               </div>
+                </div>
             `;
         };
 
@@ -212,3 +220,14 @@ export class LeftRightChooserModel {
         XH.safeDestroy(this.leftModel, this.rightModel);
     }
 }
+
+/**
+ * @typedef {Object} LeftRightChooserItem - data record object for a LeftRightChooser value item.
+ * @property {string} text - primary label for the item.
+ * @property {string} value - value that the item represents.
+ * @property {string} [description] - user-friendly, longer description of the item.
+ * @property {string} [group] - grid group in which to show the item.
+ * @property {string} [side] - initial side of the item - one of ['left', 'right'] - default left.
+ * @property {boolean} [locked] - true to prevent the user from moving the item between sides.
+ * @property {boolean} [exclude] - true to exclude the item from the chooser entirely.
+ */

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
@@ -15,10 +15,16 @@ import {convertIconToSvg, Icon} from '@xh/hoist/icon';
  */
 @HoistModel()
 export class LeftRightChooserModel {
-    /** Grid Model for the left-hand side */
+    /**
+     * Grid Model for the left-hand side
+     * @type GridModel
+     */
     leftModel = null;
 
-    /** Grid Model for the right-hand side */
+    /**
+     * Grid Model for the right-hand side
+     * @type GridModel
+     */
     rightModel = null;
 
     /** Property to enable/disable the description panel */
@@ -140,12 +146,15 @@ export class LeftRightChooserModel {
     //------------------------
     getTextColRenderer(side) {
         const groupingEnabled = side == 'left' ? this.leftGroupingEnabled : this.rightGroupingEnabled,
-            groupClass = groupingEnabled ? 'xh-lr-chooser__group-row' : '';
+            groupClass = groupingEnabled ? 'xh-lr-chooser__group-row' : '',
+            lockSvg = convertIconToSvg(Icon.lock({prefix: 'fal'}));
 
-        return (v, data, meta) => {
-            return `<div class='xh-lr-chooser__item-row ${groupClass}'>
-                        ${v}${data.locked ? convertIconToSvg(Icon.lock({prefix: 'fal'})) : ''}
-                   </div>`;
+        return (v, data) => {
+            return `
+                <div class='xh-lr-chooser__item-row ${groupClass}'>
+                    ${v} ${data.locked ? lockSvg : ''}
+               </div>
+            `;
         };
 
     }

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
@@ -27,15 +27,11 @@ export class LeftRightChooserModel {
      */
     rightModel = null;
 
-    /** True to enable the description panel. */
-    hasDescription = null;
-
-    _lastSelectedSide = null;
-
-    leftGroupingEnabled = null;
-    rightGroupingEnabled = null;
-    leftGroupingExpanded = null;
-    rightGroupingExpanded = null;
+    hasDescription = false;
+    leftGroupingEnabled = false;
+    rightGroupingEnabled = false;
+    leftGroupingExpanded = false;
+    rightGroupingExpanded = false;
 
     /**
      * Filter for data rows to determine if they should be shown.
@@ -66,18 +62,18 @@ export class LeftRightChooserModel {
 
     /**
      * @param {Object} c - LeftRightChooserModel configuration.
-     * @param {LeftRightChooserItem[]} c.data - source data for both lists, split by `side' property.
+     * @param {LeftRightChooserItemDef[]} c.data - source data for both lists, split by `side`.
      * @param {string} [c.ungroupedName] - placeholder group value when an item has no group.
      * @param {?string} [c.leftTitle] - title of the left-side list.
-     * @param {boolean} [c.leftGroupingEnabled] - true to enable grouping on the the left-side list.
-     * @param {boolean} [c.leftGroupingExpanded] - default true, false to show a grouped left-side
-     *      list with all groups initially collapsed.
-     * @param {(GridSorter|GridSorter[])} [c.leftSortBy] - sorter(s) to apply to the left-side store.
+     * @param {boolean} [c.leftGroupingEnabled] - true to enable grouping on the left-side list.
+     * @param {boolean} [c.leftGroupingExpanded] - false to show a grouped left-side list with all
+     *      groups initially collapsed.
+     * @param {(GridSorterDef|GridSorterDef[])} [c.leftSortBy] - sorter(s) for left-side store.
      * @param {?string} [c.rightTitle] - title of the right-side list.
-     * @param {boolean} [c.rightGroupingEnabled] - true to enable grouping on the the right-side list.
-     * @param {boolean} [c.rightGroupingExpanded] - default true, false to show a grouped right-side
-     *      list with all groups initially collapsed.
-     * @param {(GridSorter|GridSorter[])} [c.rightSortBy] - sorter(s) to apply to the right-side store.
+     * @param {boolean} [c.rightGroupingEnabled] - true to enable grouping on the right-side list.
+     * @param {boolean} [c.rightGroupingExpanded] - false to show a grouped right-side list with all
+     *      groups initially collapsed.
+     * @param {(GridSorterDef|GridSorterDef[])} [c.rightSortBy] - sorter(s) for right-side store.
      */
     constructor({
         data = [],
@@ -222,7 +218,7 @@ export class LeftRightChooserModel {
 }
 
 /**
- * @typedef {Object} LeftRightChooserItem - data record object for a LeftRightChooser value item.
+ * @typedef {Object} LeftRightChooserItemDef - data record object for a LeftRightChooser value item.
  * @property {string} text - primary label for the item.
  * @property {string} value - value that the item represents.
  * @property {string} [description] - user-friendly, longer description of the item.

--- a/desktop/cmp/rest/RestControlModel.js
+++ b/desktop/cmp/rest/RestControlModel.js
@@ -12,9 +12,9 @@ import {isJSON} from '@xh/hoist/utils/JsUtils';
 @HoistModel()
 export class RestControlModel  {
 
-    field
-    editor
-    parent
+    field;
+    editor;
+    parent;
 
     get record() {return this.parent.record}
 

--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -21,11 +21,12 @@ export class RestStore extends UrlStore {
     _lookupsLoaded = false;
 
     /**
-     * @param {string} url
-     * @param {string} [dataRoot] - Name of root node for records in returned data
-     * @param {boolean} [reloadLookupsOnLoad] - Whether lookups should be loaded each time
+     * @param {Object} c - RestStore configuration.
+     * @param {string} c.url - URL from which to load data.
+     * @param {?string} [c.dataRoot] - Key of root node for records in returned data object.
+     * @param {boolean} [c.reloadLookupsOnLoad] - Whether lookups should be loaded each time
      *      new data is loaded or updated by this client.
-     * @param {...*} [urlStoreArgs] - Additional arguments to pass to UrlStore.
+     * @param {...*} - Additional arguments to pass to UrlStore.
      */
     constructor({url, dataRoot = 'data', reloadLookupsOnLoad = false, ...urlStoreArgs}) {
         super({url, dataRoot, ...urlStoreArgs});

--- a/desktop/cmp/tab/container/TabContainerModel.js
+++ b/desktop/cmp/tab/container/TabContainerModel.js
@@ -19,7 +19,10 @@ import {TabModel} from '@xh/hoist/desktop/cmp/tab';
 @HoistModel()
 export class TabContainerModel {
 
-    /** TabModels included in this tab container. */
+    /**
+     * TabModels included in this tab container.
+     * @member {TabModel[]}
+     */
     tabs = [];
 
     /** Base route for this container. */
@@ -35,15 +38,21 @@ export class TabContainerModel {
     tabRenderMode = null;
 
     /**
-     * @param {Object[]} tabs - configurations for TabModels (or TabModel instances) to be displayed
+     * @param {Object} c - TabContainerModel configuration.
+     * @param {Object[]} c.tabs - configs for TabModels (or TabModel instances) to be displayed
      *      by this container.
-     * @param {string} [defaultTabId] - ID of Tab to be shown initially if routing does not specify
-     *      otherwise. If not set, will default to first tab in the provided collection.
-     * @param {string} [route] - base route name for this container. If set, this container will be
-     *      route-enabled, with the route for each tab being "[route]/[tab.id]".
-     * @param {string} [tabRenderMode] - how to render hidden tabs - [lazy|always|unmountOnHide].
+     * @param {?string} [c.defaultTabId] - ID of Tab to be shown initially if routing does not
+     *      specify otherwise. If not set, will default to first tab in the provided collection.
+     * @param {?string} [c.route] - base route name for this container. If set, this container will
+     *      be route-enabled, with the route for each tab being "[route]/[tab.id]".
+     * @param {?string} [c.tabRenderMode] - how to render hidden tabs - [lazy|always|unmountOnHide].
      */
-    constructor({tabs, defaultTabId = null, route = null, tabRenderMode = 'lazy'}) {
+    constructor({
+        tabs,
+        defaultTabId = null,
+        route = null,
+        tabRenderMode = 'lazy'
+    }) {
         this.tabRenderMode = tabRenderMode;
 
         // 1) Validate and wire tabs, instantiate if needed.
@@ -80,7 +89,7 @@ export class TabContainerModel {
      * will only be updated once the router state changes. Otherwise the active Tab will be updated
      * immediately.
      *
-     * @param {int} id - unique ID of Tab to activate.
+     * @param {string} id - unique ID of Tab to activate.
      */
     activateTab(id) {
         if (this.activeTabId === id) return;

--- a/desktop/cmp/tab/pane/TabModel.js
+++ b/desktop/cmp/tab/pane/TabModel.js
@@ -13,13 +13,15 @@ import {startCase} from 'lodash';
  * Model for a Tab within a TabContainer - manages the active and refresh state of its contents.
  *
  * This model is not typically created directly within applications. Instead, specify a
- * configuration for it via the 'tabs' property of the TabContainerModel constructor.
+ * configuration for it via the `TabContainerModel.tabs` constructor config.
  */
 @HoistModel()
 export class TabModel {
-    id = null;
-    title = null;
-    reloadOnShow = false;
+    id;
+    title;
+    reloadOnShow;
+
+    /** @member {TabContainerModel} */
     containerModel = null;
 
     @observable lastRefreshRequest = null;
@@ -27,11 +29,12 @@ export class TabModel {
     loadState = new LastPromiseModel();
 
     /**
-     * @param {string} id - unique ID, used by parent container for generating routes.
-     * @param {string} [title] - display title for the Tab in the container's TabSwitcher.
-     * @param {Object} content - content to be rendered by this Tab. Component class or a custom
+     * @param {Object} c - TabModel configuration.
+     * @param {string} c.id - unique ID, used by container for locating tabs and generating routes.
+     * @param {string} [c.title] - display title for the Tab in the container's TabSwitcher.
+     * @param {Object} c.content - content to be rendered by this Tab. Component class or a custom
      *      element factory of the form returned by elemFactory.
-     * @param {boolean} reloadOnShow - true to reload data for this tab each time it is activated.
+     * @param {boolean} [c.reloadOnShow] - true to reload data for this tab each time it is activated.
      */
     constructor({
         id,

--- a/exception/Exception.js
+++ b/exception/Exception.js
@@ -18,7 +18,8 @@ export class Exception {
 
     /**
      * Create and get back a Javascript Error object
-     * @param {(Object|string)} cfg - Properties to add to the Error object.  If a string, will become the 'message' value.
+     * @param {(Object|string)} cfg - Properties to add to the Error object.
+     *      If a string, will become the 'message' value.
      * @returns {Error}
      */
     static create(cfg) {

--- a/mobile/cmp/grid/GridModel.js
+++ b/mobile/cmp/grid/GridModel.js
@@ -22,11 +22,12 @@ export class GridModel {
     @observable hideHeader = null;
 
     /**
-     * @param {BaseStore} store - store containing the data for the grid.
-     * @param {Object} leftColumn - column specification to show in left side of grid
-     * @param {Object} rightColumn - column specification to show in right side of grid
-     * @param {function} [handler] - function to trigger on item tap. Receives record as argument.
-     * @param {boolean} [hideHeader] - true to hide the header row
+     * @param {Object} c - GridModel configuration.
+     * @param {BaseStore} c.store - store containing the data for the grid.
+     * @param {Object} c.leftColumn - column specification to show in left side of grid.
+     * @param {Object} c.rightColumn - column specification to show in right side of grid.
+     * @param {function} [c.handler] - function to trigger on item tap. Receives record as argument.
+     * @param {boolean} [c.hideHeader] - true to hide the header row.
      */
     constructor({
         store,

--- a/mobile/cmp/header/AppMenuModel.js
+++ b/mobile/cmp/header/AppMenuModel.js
@@ -9,7 +9,7 @@ import {MenuModel} from '@xh/hoist/mobile/cmp/menu';
 import {Icon} from '@xh/hoist/icon';
 
 /**
- * A standard application drop down menu, which installs a standard set of menu items for common
+ * An top-level application drop down menu, which installs a standard set of menu items for common
  * application actions. Application specific items can be displayed before these standard items.
  *
  * The standard items which are visible will be based on user roles and application configuration,
@@ -18,12 +18,13 @@ import {Icon} from '@xh/hoist/icon';
 export class AppMenuModel extends MenuModel {
 
     /**
-     * @param {Object[]} itemModels - See MenuModel.
-     * @param {number} [xPos] - See MenuModel.
-     * @param {number} [yPos] - See MenuModel.
-     * @param {bool} [hideFeedbackItem] - Set to true to hide the Feedback menu item.
-     * @param {bool} [hideThemeItem] - Set to true to hide the Theme Toggle menu item.
-     * @param {bool} [hideLogoutItem] - Set to true to hide the Logout menu item.
+     * @param {Object} c - AppMenuModel configuration.
+     * @param {Object[]} c.itemModels - See MenuModel.
+     * @param {number} [c.xPos] - See MenuModel.
+     * @param {number} [c.yPos] - See MenuModel.
+     * @param {boolean} [c.hideFeedbackItem] - true to hide the Feedback menu item.
+     * @param {boolean} [c.hideThemeItem] - true to hide the Theme Toggle menu item.
+     * @param {boolean} [c.hideLogoutItem] - true to hide the Logout menu item.
      *          Will be automatically hidden for applications with logout disabled
      */
     constructor({

--- a/mobile/cmp/menu/MenuItemModel.js
+++ b/mobile/cmp/menu/MenuItemModel.js
@@ -18,12 +18,13 @@ export class MenuItemModel {
     prepareFn;
 
     /**
-     * @param {string} text - label to be displayed.
-     * @param {Object} [icon] - optional icon to be displayed.
-     * @param {function} [action] - Executed when the user clicks the menuitem.
-     * @param {boolean} [disabled] - true to disable this item.
-     * @param {boolean} [hidden] - true to hide this item.
-     * @param {function} [prepareFn] - function of the form (item) => {}
+     * @param {Object} c - MenuItemModel configuration.
+     * @param {string} c.text - label to be displayed.
+     * @param {Object} [c.icon] - optional icon to be displayed.
+     * @param {function} [c.action] - Executed when the user clicks the menuitem.
+     * @param {boolean} [c.disabled] - true to disable this item.
+     * @param {boolean} [c.hidden] - true to hide this item.
+     * @param {function} [c.prepareFn] - function of the form (item) => {}
      *      The prepareFn is a callback that is triggered before each time the menuitem is shown.
      *      It can be used to modify the menuitem based on the record / selection.
      */

--- a/mobile/cmp/menu/MenuModel.js
+++ b/mobile/cmp/menu/MenuModel.js
@@ -20,9 +20,10 @@ export class MenuModel {
     @observable.ref itemModels = false;
 
     /**
-     * @param {Object[]} itemModels - configurations for MenuItemModels (or MenuItemModel instances).
-     * @param {number} [xPos] - Screen X position to display the menu. Can also be set via openAt().
-     * @param {number} [yPos] - Screen Y position to display the menu. Can also be set via openAt().
+     * @param {Object} c - MenuModel configuration.
+     * @param {(MenuItemModel[]|Object[])} c.itemModels - MenuItemModel instances or configs.
+     * @param {number} [c.xPos] - Screen X position to display the menu. Can be set via openAt().
+     * @param {number} [c.yPos] - Screen Y position to display the menu. Can be set via openAt().
      */
     constructor({itemModels = [], xPos = 0, yPos = 0}) {
         this.itemModels = itemModels.map(i => isPlainObject(i) ? new MenuItemModel(i) : i);

--- a/mobile/cmp/tab/container/TabContainerModel.js
+++ b/mobile/cmp/tab/container/TabContainerModel.js
@@ -20,7 +20,10 @@ import {TabModel} from '../pane/TabModel';
 @HoistModel()
 export class TabContainerModel {
 
-    /** TabModels included in this tab container. */
+    /**
+     * TabModels included in this tab container.
+     * @member {TabModel[]}
+     */
     tabs = [];
 
     /** ID of the Tab to be active by default. */
@@ -39,8 +42,10 @@ export class TabContainerModel {
     }
 
     /**
-     * @param {Object[]} tabs - configurations for TabModels (or TabModel instances).
-     * @param {String} [defaultTabId] - ID of Tab to be shown initially. If not set, will default to first tab in the provided collection.
+     * @param {Object} c - TabContainerModel configuration.
+     * @param {Object[]} c.tabs - TabModels or configs to create.
+     * @param {string} [c.defaultTabId] - ID of Tab to be shown initially.
+     *      If not set, will default to first tab in the provided collection.
      */
     constructor({
         tabs,

--- a/mobile/cmp/tab/pane/TabModel.js
+++ b/mobile/cmp/tab/pane/TabModel.js
@@ -27,13 +27,14 @@ export class TabModel {
     loadState = new LastPromiseModel();
 
     /**
-     * @param {string} id - unique ID.
-     * @param {TabContainerModel} parent - owner TabContainerModel model.
-     * @param {function} pageFactory - element factory for page component.
-     * @param {Object} [pageProps] - props to passed to page upon creation
-     * @param {boolean} [reloadOnShow] - whether to load fresh data for this tab each time it is selected
-     * @param {String} label - text to be displayed in the Tabbar.
-     * @param {Icon} [icon] - icon to be displayed in the Tabbar.
+     * @param {Object} c - TabModel configuration.
+     * @param {string} c.id - unique ID within its container.
+     * @param {TabContainerModel} c.parent - owner TabContainerModel model.
+     * @param {function} c.pageFactory - element factory for page component.
+     * @param {Object} [c.pageProps] - props to passed to page upon creation
+     * @param {boolean} [c.reloadOnShow] - whether to load fresh data for this tab each time it is selected
+     * @param {String} c.label - text to be displayed in the Tabbar.
+     * @param {Icon} [c.icon] - icon to be displayed in the Tabbar.
      */
     constructor({
         id,

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -17,14 +17,14 @@ export class FetchService {
      * the most common use-cases. The Fetch API will be called with CORS enabled, credentials
      * included, and redirects followed.
      *
-     * @see https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
+     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API|Fetch API Docs}
      *
      * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+     *      @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Request|Fetch Request docs}
      * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.params] - parameters to encode and send with the request body (for POSTs)
-     *      or append as a query string.
+     *     appended to XH.baseUrl for the request.
+     * @param {Object} [opts.params] - parameters to encode and send with the request body
+     *      (for POSTs) or append as a query string.
      * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
      *     explicitly set in opts then the method will be set to POST if there are params,
      *     otherwise it will be set to GET.
@@ -32,8 +32,9 @@ export class FetchService {
      *     If not explicitly set in opts then the contentType will be set based on the method. POST
      *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
      *     used.
-     * @param {boolean} [opts.acceptJson] - if true, sets Accept header to 'application/json'.  Defaults to false.
-     * @returns {Promise<Response>} @see https://developer.mozilla.org/en-US/docs/Web/API/Response
+     * @param {boolean} [opts.acceptJson] - true to set Accept header to 'application/json'.
+     * @returns {Promise<Response>} - Promise which resolves to a Fetch Response.
+     *      @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Fetch Response docs}
      */
     async fetch(opts) {
         let {params, method, contentType, url} = opts;
@@ -119,8 +120,7 @@ export class FetchService {
      * @returns {Promise} the decoded JSON object, or null if the response had no content.
      */
     async fetchJson(opts) {
-        opts.acceptJson = true;
-        const ret = await this.fetch(opts);
+        const ret = await this.fetch({acceptJson: true, ...opts});
         return ret.status === 204 ? null : ret.json();
     }
 

--- a/svc/IdleService.js
+++ b/svc/IdleService.js
@@ -4,18 +4,23 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-import {XH, HoistService, AppState} from '@xh/hoist/core';
+import {AppState, HoistService, XH} from '@xh/hoist/core';
 import {MINUTES} from '@xh/hoist/utils/DateTimeUtils';
-import {debounce} from 'lodash';
 import {Timer} from '@xh/hoist/utils/Timer';
+import {debounce} from 'lodash';
 
 /**
- * Manage the idling/suspension of this application after a certain period of user
- * inactivity.
+ * Manage the idling/suspension of this application after a certain period of user inactivity
+ * to cancel background tasks and prompt the user to reload the page when they wish to resume
+ * using the app. This approach is typically employed to reduce potential load on back-end
+ * system from unattended clients and/or as a "belt-and-suspenders" defence against memory
+ * leaks or other performance issues that can arise with long-running sessions.
  *
- * This service is goverened by the property App.disableIdleDetection, the configuration
- * 'xhIdleTimeoutMins', and the user-specific preference 'xh.disableIdleDetection' respectively.
- * Any of these can be used to disable app suspension.
+ * This service consults the HoistApp `idleDetectionDisabled` getter, the `xhIdleTimeoutMins`
+ * soft-config, and the `xh.disableIdleDetection` user preference to determine if and when it
+ * should suspend the app.
+ *
+ * Not currently supported / enabled for mobile clients.
  */
 @HoistService()
 export class IdleService {
@@ -35,9 +40,10 @@ export class IdleService {
         }
     }
 
-    //-------------------------------------
+
+    //------------------------
     // Implementation
-    //-------------------------------------
+    //------------------------
     createAppListeners() {
         this.ACTIVITY_EVENTS.forEach(e => addEventListener(e, this.startCountdown, true));
     }

--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -84,8 +84,8 @@ export class PrefService {
      * See pushAsync() and pushPendingAsync()
      *
      * @param {string} key
-     * @param {*} value - the new value to save
-     * @fires PrefService#prefChange - if the preference value was actually modified
+     * @param {*} value - the new value to save.
+     * @fires PrefService#prefChange - if the preference value was actually modified.
      */
     set(key, value) {
         this.validateBeforeSet(key, value);

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -20,8 +20,8 @@ export class TrackService {
      *      Required if options is an object.
      *      Can be passed as `message` for backwards compatibility.
      * @param {string} [options.category] - app-supplied category.
-     * @param {(Object|Array)} [options.data] - app-supplied data collection.
-     * @param {number} [options.elapsed] - time in milliseconds some activity took.
+     * @param {(Object|Object[])} [options.data] - app-supplied data collection.
+     * @param {number} [options.elapsed] - time in milliseconds the activity took.
      * @param {string} [options.severity] - importance flag, such as: OK|WARN|EMERGENCY
      *      (errors should be tracked by the ErrorTrackingService, not sent in this TrackService).
      */


### PR DESCRIPTION
+ Additional standardization / completion of public-facing API docs throughout.
+ Add constructor documentation for new Column API. 
+ Mirror service API signatures for XH aliases - they are not overly complex/dynamic, and XH is a primary entry point. (Ideally we would find a way to syndicate the actual docs to these methods...).
+ Remove `contextMenuItem.prepareFn` - this was documented as if it were a storeContextMenuItem but unused / not clearly applicable. Left / improved docs on the store variant.
+ Updated `GridStateModel.xhStateId` -> `gridId` - no need for "xh" prefix on a property of a class created and wholly managed by the toolkit.
+ Use of `@typedef` annotations to clarify some doc comments / APIs.
+ Use of `@member` annotations w/typing on certain key public properties.
+ Fixes #336
+ Fixes #515
+ Fixes #525