### PR TITLE
Support posting JSON body with content-type application/json.

### DIFF
--- a/core/XH.js
+++ b/core/XH.js
@@ -309,6 +309,8 @@ class XHClass {
     track(opts)                 {return this.trackService.track(opts)}
     fetch(opts)                 {return this.fetchService.fetch(opts)}
     fetchJson(opts)             {return this.fetchService.fetchJson(opts)}
+    postJson(opts)              {return this.fetchService.postJson(opts)}
+    putJson(opts)               {return this.fetchService.putJson(opts)}
     getUser()                   {return this.identityService.getUser()}
     getUsername()               {return this.identityService.getUsername()}
     getConf(key, defaultVal)    {return this.configService.get(key, defaultVal)}

--- a/core/XH.js
+++ b/core/XH.js
@@ -309,8 +309,6 @@ class XHClass {
     track(opts)                 {return this.trackService.track(opts)}
     fetch(opts)                 {return this.fetchService.fetch(opts)}
     fetchJson(opts)             {return this.fetchService.fetchJson(opts)}
-    postJson(opts)              {return this.fetchService.postJson(opts)}
-    putJson(opts)               {return this.fetchService.putJson(opts)}
     getUser()                   {return this.identityService.getUser()}
     getUsername()               {return this.identityService.getUsername()}
     getConf(key, defaultVal)    {return this.configService.get(key, defaultVal)}

--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -69,11 +69,9 @@ export class RestStore extends UrlStore {
     async saveRecordInternalAsync(rec, isAdd) {
         let {url} = this;
         if (!isAdd) url += '/' + rec.id;
-        return XH.fetchJson({
+        return XH[isAdd ? 'postJson' : 'putJson']({
             url,
-            method: isAdd ? 'POST' : 'PUT',
-            contentType: 'application/json',
-            body: JSON.stringify({data: rec})
+            body: {data: rec}
         }).then(response => {
             const recs = this.createRecordMap([response.data]);
             this.updateRecordInternal(recs.values().next().value);

--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -69,7 +69,7 @@ export class RestStore extends UrlStore {
     async saveRecordInternalAsync(rec, isAdd) {
         let {url} = this;
         if (!isAdd) url += '/' + rec.id;
-        return XH[isAdd ? 'postJson' : 'putJson']({
+        return XH.fetchService[isAdd ? 'postJson' : 'putJson']({
             url,
             body: {data: rec}
         }).then(response => {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "numeral": "~2.0.6",
     "onsenui": "~2.10.1",
     "prop-types": "~15.6.2",
+    "qs": "^6.5.2",
     "react-onsenui": "~1.11.0",
     "react-transition-group": "~2.4.0",
     "router5": "~6.4.2",

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -10,6 +10,63 @@ import {stringify} from 'qs';
 
 @HoistService()
 export class FetchService {
+
+    /**
+     * Send an HTTP request to a URL, and decode the response as JSON.
+     *
+     * @param {Object} opts - options to pass through to fetch, with some additions.
+     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
+     *     appended to XH.baseUrl for the request
+     * @param {Object} [opts.params] - parameters to encode and send with the request body (for POSTs)
+     *      or append as a query string.
+     * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
+     *     explicitly set in opts then the method will be set to POST if there are params,
+     *     otherwise it will be set to GET.
+     * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
+     *     If not explicitly set in opts then the contentType will be set based on the method. POST
+     *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
+     *     used.
+     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
+     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
+     *     These may be overriden by passing in a qsOpts object.
+     *     @see {@link https://www.npmjs.com/package/qs}
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async fetchJson(opts) {
+        const ret = await this.fetch({acceptJson: true, ...opts});
+        return ret.status === 204 ? null : ret.json();
+    }
+
+
+    /**
+     * Send a POST/PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
+     *
+     * @param {Object} opts - options to pass through to fetch, with some additions.
+     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
+     *     appended to XH.baseUrl for the request
+     * @param {Object} [opts.body] - the data obj to send in the request body.
+     * @param {Object} [opts.params] - parameters to encode and send as a query string.
+     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
+     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
+     *     These may be overriden by passing in a qsOpts object.
+     *     @see {@link https://www.npmjs.com/package/qs}
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async postJson(opts) {
+        opts.method = 'POST';
+        return this.sendJson(opts);
+    }
+
+    /**
+     * @see {docs for postJson}
+     */
+    async putJson(opts) {
+        opts.method = 'PUT';
+        return this.sendJson(opts);
+    }
+
     /**
      * Send an HTTP request to a URL.
      *
@@ -105,89 +162,16 @@ export class FetchService {
         return ret;
     }
 
-    /**
-     * Send an HTTP request to a URL, and decode the response as JSON.
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.params] - parameters to encode and send with the request body (for POSTs)
-     *      or append as a query string.
-     * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
-     *     explicitly set in opts then the method will be set to POST if there are params,
-     *     otherwise it will be set to GET.
-     * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
-     *     If not explicitly set in opts then the contentType will be set based on the method. POST
-     *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
-     *     used.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *     These may be overriden by passing in a qsOpts object.
-     *     @see {@link https://www.npmjs.com/package/qs}
-     * @returns {Promise} the decoded JSON object, or null if the response had no content.
-     */
-    async fetchJson(opts) {
-        const ret = await this.fetch({acceptJson: true, ...opts});
-        return ret.status === 204 ? null : ret.json();
-    }
-
-
-    /**
-     * Send a POST HTTP request to a URL with a JSON body, and decode the response as JSON.
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.body] - the data obj to send in the request body.
-     * @param {Object} [opts.params] - parameters to encode and send as a query string.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *     These may be overriden by passing in a qsOpts object.
-     *     @see {@link https://www.npmjs.com/package/qs}
-     * @returns {Promise} the decoded JSON object, or null if the response had no content.
-     */
-    async postJson(opts) {
-        opts.body = JSON.stringify(opts.body);
-        const ret = await this.fetch({
-            method: 'POST',
-            acceptJson: true,
-            contentType: 'application/json',
-            ...opts
-        });
-        return ret.status === 204 ? null : ret.json();
-    }
-
-    /**
-     * Send a PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.body] - the data obj to send in the request body.
-     * @param {Object} [opts.params] - parameters to encode and send as a query string.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *     These may be overriden by passing in a qsOpts object.
-     *     @see {@link https://www.npmjs.com/package/qs}
-     * @returns {Promise} the decoded JSON object, or null if the response had no content.
-     */
-    async putJson(opts) {
-        opts.body = JSON.stringify(opts.body);
-        const ret = await this.fetch({
-            method: 'PUT',
-            acceptJson: true,
-            contentType: 'application/json',
-            ...opts
-        });
-        return ret.status === 204 ? null : ret.json();
-    }
-
     //-----------------------
     // Implementation
     //-----------------------
+    async sendJson(opts) {
+        opts = Object.assign(opts, {
+            body: JSON.stringify(opts.body),
+            contentType: 'application/json'
+        });
+        return this.fetchJson(opts);
+    }
 
     async safeResponseTextAsync(response) {
         try {

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -132,10 +132,8 @@ export class FetchService {
 
         // 3) Preprocess and apply params
         if (params) {
-            let qsOpts = {arrayFormat: 'repeat', allowDots: true};
-            qsOpts = Object.assign(qsOpts, opts.qsOpts);
-
-            const paramsString = stringify(params, qsOpts);
+            const qsOpts = {arrayFormat: 'repeat', allowDots: true, ...opts.qsOpts},
+                paramsString = stringify(params, qsOpts);
 
             if (['POST', 'PUT'].includes(method) && fetchOpts.contentType != 'application/json') {
                 // fall back to an 'application/x-www-form-urlencoded' POST/PUT body if not sending json
@@ -166,10 +164,10 @@ export class FetchService {
     // Implementation
     //-----------------------
     async sendJson(opts) {
-        opts = Object.assign(opts, {
+        opts = {...opts, ...{
             body: JSON.stringify(opts.body),
             contentType: 'application/json'
-        });
+        }};
         return this.fetchJson(opts);
     }
 

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -17,63 +17,36 @@ import {stringify} from 'qs';
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API|Fetch API Docs}
  *
- * The convenience methods 'fetchJson', 'postJson', 'putJson' all use the 'opts' arg and pass it on to
- * 'fetch', but with some 'opts' properties pre-set.
- *
- *
- * @param {Object} opts - options to pass through to fetch, with some additions.
- *     @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
- * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
- *     appended to XH.baseUrl for the request.
- * @param {Object} [opts.body] - the data obj to send in the request body (for POSTs/PUTs sending JSON).
- * @param {Object} [opts.params] - parameters to encode and send with the request body
- *      (for POSTs/PUTs sending form-url-encoded) or to append as a query string.
- * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
- *     explicitly set in opts then the method will be set to POST if there are params,
- *     otherwise it will be set to GET.
- * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
- *     If not explicitly set in opts then the contentType will be set based on the method. POST
- *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
- *     used.
- * @param {boolean} [opts.acceptJson] - true to set Accept header to 'application/json'.
- * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
- *      The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
- *      These may be overriden by passing in a qsOpts object.
- *      @see {@link https://www.npmjs.com/package/qs}
+ * Note that the convenience methods 'fetchJson', 'postJson', 'putJson' all accept the same options as
+ * the main entry point 'fetch'.  These methods delegate to fetch, after setting appropriate additional
+ * defaults.
  */
 @HoistService()
 export class FetchService {
 
     /**
-     * Send an HTTP request to a URL, and decode the response as JSON.
-     * @returns {Promise} the decoded JSON object, or null if the response had no content.
-     */
-    async fetchJson(opts) {
-        const ret = await this.fetch({acceptJson: true, ...opts});
-        return ret.status === 204 ? null : ret.json();
-    }
-
-    /**
-     * Send a POST HTTP request to a URL with a JSON body, and decode the response as JSON.
-     * @returns {Promise} @see {fetchJson}
-     */
-    async postJson(opts) {
-        opts.method = 'POST';
-        return this.sendJson(opts);
-    }
-
-    /**
-     * Send a PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
-     * @returns {Promise} @see {fetchJson}
-     */
-    async putJson(opts) {
-        opts.method = 'PUT';
-        return this.sendJson(opts);
-    }
-
-    /**
+     * Send a request via the underlying fetch API.
+     *
+     * @param {Object} opts - standard options to pass through to fetch, with some additions.
+     *     @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
+     *     appended to XH.baseUrl for the request.
+     * @param {Object} [opts.body] - the data obj to send in the request body (for POSTs/PUTs sending JSON).
+     * @param {Object} [opts.params] - parameters to encode and send with the request body
+     *      (for POSTs/PUTs sending form-url-encoded) or to append as a query string.
+     * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
+     *     explicitly set in opts then the method will be set to POST if there are params,
+     *     otherwise it will be set to GET.
+     * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
+     *     If not explicitly set in opts then the contentType will be set based on the method. POST
+     *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
+     *     used.
+     * @param {boolean} [opts.acceptJson] - true to set Accept header to 'application/json'.
+     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter library, qs.
+     *      The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
+     *      @see {@link https://www.npmjs.com/package/qs}
+     *
      * @returns {Promise<Response>} - Promise which resolves to a Fetch Response.
-     *      @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Fetch Response docs}
      */
     async fetch(opts) {
         let {params, method, contentType, url} = opts;
@@ -137,14 +110,51 @@ export class FetchService {
         return ret;
     }
 
+    /**
+     * Send an HTTP request to a URL, and decode the response as JSON.
+     *
+     * This method delegates to @see {fetch} and accepts the same options.
+     *
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async fetchJson(opts) {
+        const ret = await this.fetch({acceptJson: true, ...opts});
+        return ret.status === 204 ? null : ret.json();
+    }
+
+    /**
+     * Send a POST HTTP request to a URL with a JSON body, and decode the response as JSON.
+     *
+     * This method delegates to @see {fetch} and accepts the same options.
+     *
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async postJson(opts) {
+        opts.method = 'POST';
+        return this.sendJson(opts);
+    }
+
+    /**
+     * Send a PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
+     *
+     * This method delegates to @see {fetch} and accepts the same options.
+     *
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async putJson(opts) {
+        opts.method = 'PUT';
+        return this.sendJson(opts);
+    }
+
     //-----------------------
     // Implementation
     //-----------------------
     async sendJson(opts) {
-        opts = {...opts, ...{
+        opts = {
+            ...opts,
             body: JSON.stringify(opts.body),
             contentType: 'application/json'
-        }};
+        };
         return this.fetchJson(opts);
     }
 

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -78,11 +78,13 @@ export class FetchService {
             let qsOpts = {arrayFormat: 'repeat', allowDots: true};
             qsOpts = Object.assign(qsOpts, opts.qsOpts);
 
+            const paramsString = stringify(params, qsOpts);
+
             if (['POST', 'PUT'].includes(method) && fetchOpts.contentType != 'application/json') {
                 // fall back to an 'application/x-www-form-urlencoded' POST/PUT body if not sending json
-                fetchOpts.body = stringify(params, qsOpts);
+                fetchOpts.body = paramsString;
             } else {
-                url += '?' + stringify(params, qsOpts);
+                url += '?' + paramsString;
             }
         }
 

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -122,6 +122,28 @@ export class FetchService {
         return ret.status === 204 ? null : ret.json();
     }
 
+
+    /**
+     * Send a POST HTTP request to a URL with a JSON body, and decode the response as JSON.
+     *
+     * @param {Object} opts - options to pass through to fetch, with some additions.
+     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
+     *     appended to XH.baseUrl for the request
+     * @param {Object} [opts.params] - parameters to encode and send with the request body (for POSTs)
+     *      or append as a query string.
+     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     */
+    async postJson(opts) {
+        const ret = await this.fetch({
+            method: 'POST',
+            acceptJson: true,
+            contentType: 'application/json',
+            ...opts
+        });
+        return ret.status === 204 ? null : ret.json();
+    }
+
     //-----------------------
     // Implementation
     //-----------------------

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -8,29 +8,44 @@ import {XH, HoistService} from '@xh/hoist/core';
 import {Exception} from '@xh/hoist/exception';
 import {stringify} from 'qs';
 
+/**
+ * Service to send an HTTP request to a URL.
+ *
+ * Wrapper around the standard Fetch API with some enhancements to streamline the process for
+ * the most common use-cases. The Fetch API will be called with CORS enabled, credentials
+ * included, and redirects followed.
+ *
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API|Fetch API Docs}
+ *
+ * The convenience methods 'fetchJson', 'postJson', 'putJson' all use the 'opts' arg and pass it on to
+ * 'fetch', but with some 'opts' properties pre-set.
+ *
+ *
+ * @param {Object} opts - options to pass through to fetch, with some additions.
+ *     @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
+ * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
+ *     appended to XH.baseUrl for the request.
+ * @param {Object} [opts.body] - the data obj to send in the request body (for POSTs/PUTs sending JSON).
+ * @param {Object} [opts.params] - parameters to encode and send with the request body
+ *      (for POSTs/PUTs sending form-url-encoded) or to append as a query string.
+ * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
+ *     explicitly set in opts then the method will be set to POST if there are params,
+ *     otherwise it will be set to GET.
+ * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
+ *     If not explicitly set in opts then the contentType will be set based on the method. POST
+ *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
+ *     used.
+ * @param {boolean} [opts.acceptJson] - true to set Accept header to 'application/json'.
+ * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
+ *      The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
+ *      These may be overriden by passing in a qsOpts object.
+ *      @see {@link https://www.npmjs.com/package/qs}
+ */
 @HoistService()
 export class FetchService {
 
     /**
      * Send an HTTP request to a URL, and decode the response as JSON.
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.params] - parameters to encode and send with the request body (for POSTs)
-     *      or append as a query string.
-     * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
-     *     explicitly set in opts then the method will be set to POST if there are params,
-     *     otherwise it will be set to GET.
-     * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
-     *     If not explicitly set in opts then the contentType will be set based on the method. POST
-     *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
-     *     used.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *     These may be overriden by passing in a qsOpts object.
-     *     @see {@link https://www.npmjs.com/package/qs}
      * @returns {Promise} the decoded JSON object, or null if the response had no content.
      */
     async fetchJson(opts) {
@@ -38,21 +53,9 @@ export class FetchService {
         return ret.status === 204 ? null : ret.json();
     }
 
-
     /**
-     * Send a POST/PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see https://developer.mozilla.org/en-US/docs/Web/API/Request for the available options
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request
-     * @param {Object} [opts.body] - the data obj to send in the request body.
-     * @param {Object} [opts.params] - parameters to encode and send as a query string.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *     The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *     These may be overriden by passing in a qsOpts object.
-     *     @see {@link https://www.npmjs.com/package/qs}
-     * @returns {Promise} the decoded JSON object, or null if the response had no content.
+     * Send a POST HTTP request to a URL with a JSON body, and decode the response as JSON.
+     * @returns {Promise} @see {fetchJson}
      */
     async postJson(opts) {
         opts.method = 'POST';
@@ -60,7 +63,8 @@ export class FetchService {
     }
 
     /**
-     * @see {docs for postJson}
+     * Send a PUT HTTP request to a URL with a JSON body, and decode the response as JSON.
+     * @returns {Promise} @see {fetchJson}
      */
     async putJson(opts) {
         opts.method = 'PUT';
@@ -68,33 +72,6 @@ export class FetchService {
     }
 
     /**
-     * Send an HTTP request to a URL.
-     *
-     * Wrapper around the standard Fetch API with some enhancements to streamline the process for
-     * the most common use-cases. The Fetch API will be called with CORS enabled, credentials
-     * included, and redirects followed.
-     *
-     * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API|Fetch API Docs}
-     *
-     * @param {Object} opts - options to pass through to fetch, with some additions.
-     *      @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Request|Fetch Request docs}
-     * @param {string} opts.url - target url to send the HTTP request to. Relative urls will be
-     *     appended to XH.baseUrl for the request.
-     * @param {Object} [opts.body] - the data obj to send in the request body (for POSTs/PUTs sending JSON).
-     * @param {Object} [opts.params] - parameters to encode and send with the request body
-     *      (for POSTs/PUTs sending form-url-encoded) or to append as a query string.
-     * @param {string} [opts.method] - The HTTP Request method to use for the request. If not
-     *     explicitly set in opts then the method will be set to POST if there are params,
-     *     otherwise it will be set to GET.
-     * @param {string} [opts.contentType] - value to use in the Content-Type header in the request.
-     *     If not explicitly set in opts then the contentType will be set based on the method. POST
-     *     requests will use 'application/x-www-form-urlencoded', otherwise 'text/plain' will be
-     *     used.
-     * @param {boolean} [opts.acceptJson] - true to set Accept header to 'application/json'.
-     * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter, qs.
-     *      The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
-     *      These may be overriden by passing in a qsOpts object.
-     *      @see {@link https://www.npmjs.com/package/qs}
      * @returns {Promise<Response>} - Promise which resolves to a Fetch Response.
      *      @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Response|Fetch Response docs}
      */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5934,7 +5934,7 @@ qs@6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-qs@~6.5.1, qs@~6.5.2:
+qs@^6.5.2, qs@~6.5.1, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
 


### PR DESCRIPTION
This change is part of improvements made to the framework to support a proxy service (https://github.com/exhi/hoist-core/issues/49)

Many api calls will be made with posting a json body, which our current fetch wrapper does not support.