### PR TITLE
Changed class names and margins

### DIFF
--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -121,11 +121,11 @@ export class Grid extends Component {
             icons: {
                 groupExpanded: convertIconToSvg(
                     Icon.chevronDown(),
-                    {classes: ['group-header-icon-expanded']}
+                    {classes: ['group-header-icon-expanded', 'fa-fw']}
                 ),
                 groupContracted: convertIconToSvg(
                     Icon.chevronRight(),
-                    {classes: ['group-header-icon-contracted']}
+                    {classes: ['group-header-icon-contracted', 'fa-fw']}
                 )
             },
             rowSelection: model.selModel.mode,

--- a/desktop/cmp/grid/ag-grid/styles.scss
+++ b/desktop/cmp/grid/ag-grid/styles.scss
@@ -56,7 +56,7 @@
     }
 
     .group-header-icon-contracted {
-      margin: var(--xh-pad-half-px) 8px 0 8px;
+      margin: var(--xh-pad-half-px) var(--xh-pad-half-px) 0 var(--xh-pad-half-px);
     }
   }
 


### PR DESCRIPTION
Used FontAwesome's .fa-fw class to align header text in grouped grid. Note this requires the expanded/collapsed <span> containers to have equal margins. Documentation on .fa-fw [here](https://fontawesome.com/how-to-use/on-the-web/styling/fixed-width-icons).