### PR TITLE
Pass the store through to the data view item component

### DIFF
--- a/desktop/cmp/dataview/DataView.js
+++ b/desktop/cmp/dataview/DataView.js
@@ -7,8 +7,7 @@
 
 import {Component} from 'react';
 import {XH, HoistComponent, elemFactory, LayoutSupport} from '@xh/hoist/core';
-import {grid} from '@xh/hoist/desktop/cmp/grid';
-import {GridModel} from '@xh/hoist/desktop/cmp/grid';
+import {grid, GridModel} from '@xh/hoist/desktop/cmp/grid';
 
 /**
  * A DataView is a specialized version of the Grid component. It displays its data within a
@@ -34,7 +33,7 @@ export class DataView extends Component {
                 {
                     colId: 'data',
                     flex: true,
-                    elementRenderer: (record) => itemFactory({record: record.data}),
+                    elementRenderer: (params) => itemFactory({record: params.data, store}),
                     agOptions: {
                         valueGetter: (params) => params.data
                     }

--- a/desktop/cmp/dataview/DataViewModel.js
+++ b/desktop/cmp/dataview/DataViewModel.js
@@ -38,7 +38,7 @@ export class DataViewModel {
     /**
      * @param {Object} c - DataViewModel configuration.
      * @param {function} c.itemFactory - elemFactory for the component used to render each item.
-     *      Will receive record via its props.
+     *      Will receive record and store via its props.
      * @param {BaseStore} c.store - store containing the data to be displayed.
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` from which to create.


### PR DESCRIPTION
Minor enhancement to pass the DataView store in the item component props (along with the item record). The need for this arose in a client app where my data view items have buttons to perform crud operations so they need access to the store.