### PR TITLE
Support for markClass

### DIFF
--- a/cmp/form/HoistField.js
+++ b/cmp/form/HoistField.js
@@ -92,7 +92,7 @@ export class HoistField extends Component {
      */
     getField() {
         const {model, field} = this.props;
-        return model && field && model.getField && model.getField(field);
+        return model && field && model.hasFieldSupport && model.getField(field);
     }
 
     //-----------------------------------------------------------

--- a/core/HoistApp.js
+++ b/core/HoistApp.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-import {defaultMethods} from '@xh/hoist/utils/js';
+import {defaultMethods, markClass} from '@xh/hoist/utils/js';
 import {HoistModel} from './HoistModel';
 
 /**
@@ -20,7 +20,7 @@ import {HoistModel} from './HoistModel';
  * application bootstrap file.
  */
 export function HoistApp(C) {
-    C.isHoistApp = true;
+    markClass(C, 'isHoistApp');
 
     C = HoistModel()(C);
 

--- a/core/HoistComponent.js
+++ b/core/HoistComponent.js
@@ -7,7 +7,7 @@
 import ReactDom from 'react-dom';
 import {XH} from '@xh/hoist/core';
 import {observer} from '@xh/hoist/mobx';
-import {defaultMethods, chainMethods} from '@xh/hoist/utils/js';
+import {defaultMethods, chainMethods, markClass} from '@xh/hoist/utils/js';
 import classNames from 'classnames';
 
 import {ReactiveSupport} from './mixins/ReactiveSupport';
@@ -28,7 +28,7 @@ import {elemFactory} from './elem';
 export function HoistComponent({isReactive = true} = {}) {
 
     return (C) => {
-        C.isHoistComponent = true;
+        markClass(C, 'isHoistComponent');
 
         if (isReactive) {
             C = ReactiveSupport(C);

--- a/core/HoistModel.js
+++ b/core/HoistModel.js
@@ -6,6 +6,8 @@
  */
 import {EventSupport} from './mixins/EventSupport';
 import {ReactiveSupport} from './mixins/ReactiveSupport';
+import {markClass} from '@xh/hoist/utils/js';
+
 
 /**
  * Core decorator for State Models in Hoist.
@@ -16,7 +18,7 @@ import {ReactiveSupport} from './mixins/ReactiveSupport';
 export function HoistModel() {
 
     return (C) => {
-        C.isHoistModel = true;
+        markClass(C, 'isHoistModel');
 
         C = EventSupport(C);
         C = ReactiveSupport(C);

--- a/core/HoistService.js
+++ b/core/HoistService.js
@@ -6,7 +6,7 @@
  */
 import {XH} from '@xh/hoist/core';
 import {allSettled} from '@xh/hoist/promise';
-import {defaultMethods} from '@xh/hoist/utils/js';
+import {defaultMethods, markClass} from '@xh/hoist/utils/js';
 
 import {EventSupport} from './mixins/EventSupport';
 import {ReactiveSupport} from './mixins/ReactiveSupport';
@@ -21,7 +21,7 @@ import {ReactiveSupport} from './mixins/ReactiveSupport';
 export function HoistService() {
 
     return (C) => {
-        C.isHoistService = true;
+        markClass(C, 'isHoistService');
 
         C = EventSupport(C);
         C = ReactiveSupport(C);

--- a/core/mixins/EventSupport.js
+++ b/core/mixins/EventSupport.js
@@ -7,14 +7,14 @@
 
 import {pull} from 'lodash';
 import {wait} from '@xh/hoist/promise';
-import {provideMethods, chainMethods} from '@xh/hoist/utils/js';
+import {provideMethods, chainMethods, markClass} from '@xh/hoist/utils/js';
 
 /**
  * Provide support for adding and removing listeners and firing events on itself.
  */
 export function EventSupport(C) {
-    C.hasEventSupport = true;
-
+    
+    markClass(C, 'hasEventSupport');
     provideMethods(C, {
 
         /**

--- a/core/mixins/LayoutSupport.js
+++ b/core/mixins/LayoutSupport.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {provideMethods} from '@xh/hoist/utils/js';
+import {provideMethods, markClass} from '@xh/hoist/utils/js';
 import {pick, isNumber, forOwn, omit} from 'lodash';
 
 /**
@@ -28,7 +28,7 @@ import {pick, isNumber, forOwn, omit} from 'lodash';
  */
 export function LayoutSupport(C) {
 
-    C.hasLayoutSupport = true;
+    markClass(C, 'hasLayoutSupport');
 
     // Instance methods
     provideMethods(C, {

--- a/core/mixins/ReactiveSupport.js
+++ b/core/mixins/ReactiveSupport.js
@@ -7,7 +7,7 @@
 
 import {isFunction} from 'lodash';
 import {autorun, reaction} from '@xh/hoist/mobx';
-import {provideMethods, chainMethods} from '@xh/hoist/utils/js';
+import {provideMethods, chainMethods, markClass} from '@xh/hoist/utils/js';
 
 /**
  * Mixin to add MobX reactivity to Components, Models, and Services.
@@ -20,7 +20,7 @@ import {provideMethods, chainMethods} from '@xh/hoist/utils/js';
  */
 export function ReactiveSupport(C) {
 
-    C.hasReactiveSupport = true;
+    markClass(C, 'hasReactiveSupport');
 
     provideMethods(C, {
 

--- a/desktop/cmp/contextmenu/ContextMenuSupport.js
+++ b/desktop/cmp/contextmenu/ContextMenuSupport.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {defaultMethods} from '@xh/hoist/utils/js';
+import {defaultMethods, markClass} from '@xh/hoist/utils/js';
 import {contextMenu} from './ContextMenu';
 import {ContextMenuTarget} from '@xh/hoist/kit/blueprint';
 
@@ -17,7 +17,8 @@ import {ContextMenuTarget} from '@xh/hoist/kit/blueprint';
  * See the BlueprintJS docs for more information about the implementation of this mixin.
  */
 export function ContextMenuSupport(C) {
-    C.hasContextMenuSupport = true;
+
+    markClass(C, 'hasContextMenuSupport');
 
     defaultMethods(C, {
 

--- a/field/FieldSupport.js
+++ b/field/FieldSupport.js
@@ -6,7 +6,7 @@
  */
 
 import {XH} from '@xh/hoist/core';
-import {defaultMethods, chainMethods} from '@xh/hoist/utils/js';
+import {defaultMethods, chainMethods, markClass} from '@xh/hoist/utils/js';
 import {startCase, partition, isFunction, isEmpty, isString, forOwn} from 'lodash';
 
 import {Field} from './Field';
@@ -27,8 +27,8 @@ import {ValidationState} from './validation/ValidationState';
  */
 export function FieldSupport(C) {
 
-    C.hasFieldSupport = true;
-
+    markClass(C, 'hasFieldSupport');
+    
     defaultMethods(C, {
 
         //-----------------------------

--- a/utils/js/ClassUtils.js
+++ b/utils/js/ClassUtils.js
@@ -8,6 +8,23 @@
 import {forOwn, isPlainObject} from 'lodash';
 import {throwIf} from '@xh/hoist/utils/js';
 
+
+/**
+ * Decorate a class and its instances with a boolean flag set to true.
+ *
+ * Useful for providing an identifying flag for marking objects.  Frequently used
+ * in mixins to add 'isXXX' or 'hasXXXX' identifiers.
+ *
+ * For an example, see HoistComponent and the 'isHoistComponent' property.
+ *
+ * @param {String} flag
+ */
+export function markClass(C, flag) {
+    C[flag] = true;
+    C.prototype[flag] = true;
+}
+
+
 /**
  * Provide default methods on the prototype of a class.
  *

--- a/utils/js/ClassUtils.js
+++ b/utils/js/ClassUtils.js
@@ -10,7 +10,7 @@ import {throwIf} from '@xh/hoist/utils/js';
 
 
 /**
- * Decorate a class and its instances with a boolean flag set to true.
+ * Mark a class and its instances with a boolean property set to true.
  *
  * Useful for providing an identifying flag for marking objects.  Frequently used
  * in mixins to add 'isXXX' or 'hasXXXX' identifiers.
@@ -20,8 +20,9 @@ import {throwIf} from '@xh/hoist/utils/js';
  * @param {String} flag
  */
 export function markClass(C, flag) {
-    C[flag] = true;
-    C.prototype[flag] = true;
+    const def = {value: true, writable: false};
+    Object.defineProperty(C, flag, def);
+    Object.defineProperty(C.prototype, flag, def);
 }
 
 


### PR DESCRIPTION
This formalizes (and fixes) our evolving ad-hoc method for marking classes in mixins with an identifying flag. 

Also, actually using this now to introspect the presence of FieldSupport.