### PR TITLE
Remove parameterization of HoistService/HoistModel/HoistComponent

### DIFF
--- a/admin/AppComponent.js
+++ b/admin/AppComponent.js
@@ -16,7 +16,7 @@ import {ContextMenuItem, ContextMenuSupport} from '@xh/hoist/desktop/cmp/context
 
 import './App.scss';
 
-@HoistComponent()
+@HoistComponent
 @ContextMenuSupport
 export class AppComponent extends Component {
     render() {

--- a/admin/tabs/activity/ActivityTab.js
+++ b/admin/tabs/activity/ActivityTab.js
@@ -12,7 +12,7 @@ import {TrackingPanel} from './tracking/TrackingPanel';
 import {ClientErrorPanel} from './clienterrors/ClientErrorPanel';
 import {FeedbackPanel} from './feedback/FeedbackPanel';
 
-@HoistComponent()
+@HoistComponent
 export class ActivityTab extends Component {
 
     localModel = new TabContainerModel({

--- a/admin/tabs/activity/clienterrors/ClientErrorDetail.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorDetail.js
@@ -14,7 +14,7 @@ import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {fmtDateTime} from '@xh/hoist/format';
 
-@HoistComponent()
+@HoistComponent
 export class ClientErrorDetail extends Component {
 
     render() {

--- a/admin/tabs/activity/clienterrors/ClientErrorModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorModel.js
@@ -14,7 +14,7 @@ import {fmtDate} from '@xh/hoist/format';
 import {boolCheckCol, compactDateCol} from '@xh/hoist/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 
-@HoistModel()
+@HoistModel
 export class ClientErrorModel {
 
     @observable startDate = moment().subtract(7, 'days').toDate();

--- a/admin/tabs/activity/clienterrors/ClientErrorPanel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorPanel.js
@@ -18,7 +18,7 @@ import {Icon} from '@xh/hoist/icon';
 import {ClientErrorModel} from './ClientErrorModel';
 import {clientErrorDetail} from './ClientErrorDetail';
 
-@HoistComponent()
+@HoistComponent
 export class ClientErrorPanel extends Component {
 
     localModel = new ClientErrorModel();

--- a/admin/tabs/activity/feedback/FeedbackPanel.js
+++ b/admin/tabs/activity/feedback/FeedbackPanel.js
@@ -10,7 +10,7 @@ import {restGrid, RestGridModel, RestStore} from '@xh/hoist/desktop/cmp/rest';
 import {compactDateCol} from '@xh/hoist/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 
-@HoistComponent()
+@HoistComponent
 export class FeedbackPanel extends Component {
 
     localModel = new RestGridModel({

--- a/admin/tabs/activity/tracking/ActivityDetail.js
+++ b/admin/tabs/activity/tracking/ActivityDetail.js
@@ -13,7 +13,7 @@ import {jsonField} from '@xh/hoist/desktop/cmp/form';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {fmtDateTime} from '@xh/hoist/format';
 
-@HoistComponent()
+@HoistComponent
 export class ActivityDetail extends Component {
 
     render() {

--- a/admin/tabs/activity/tracking/ActivityGrid.js
+++ b/admin/tabs/activity/tracking/ActivityGrid.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
 
 import {activityDetail} from './ActivityDetail';
 
-@HoistComponent()
+@HoistComponent
 export class ActivityGrid extends Component {
 
     render() {

--- a/admin/tabs/activity/tracking/ActivityGridModel.js
+++ b/admin/tabs/activity/tracking/ActivityGridModel.js
@@ -13,7 +13,7 @@ import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {dateTimeCol} from '@xh/hoist/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 
-@HoistModel()
+@HoistModel
 export class ActivityGridModel {
 
     @observable startDate = moment().toDate();

--- a/admin/tabs/activity/tracking/TrackingPanel.js
+++ b/admin/tabs/activity/tracking/TrackingPanel.js
@@ -13,7 +13,7 @@ import {ActivityGridModel} from './ActivityGridModel';
 import {visitsChart} from './VisitsChart';
 import {VisitsChartModel} from './VisitsChartModel';
 
-@HoistComponent()
+@HoistComponent
 export class TrackingPanel extends Component {
 
     activityGridModel = new ActivityGridModel();

--- a/admin/tabs/activity/tracking/VisitsChart.js
+++ b/admin/tabs/activity/tracking/VisitsChart.js
@@ -14,7 +14,7 @@ import {refreshButton} from '@xh/hoist/desktop/cmp/button';
 import {chart} from '@xh/hoist/desktop/cmp/chart';
 import {Icon} from '@xh/hoist/icon';
 
-@HoistComponent()
+@HoistComponent
 export class VisitsChart extends Component {
     
     render() {

--- a/admin/tabs/activity/tracking/VisitsChartModel.js
+++ b/admin/tabs/activity/tracking/VisitsChartModel.js
@@ -12,7 +12,7 @@ import {ChartModel} from '@xh/hoist/desktop/cmp/chart';
 import {fmtDate} from '@xh/hoist/format';
 import {PanelSizingModel} from '@xh/hoist/desktop/cmp/panel';
 
-@HoistModel()
+@HoistModel
 export class VisitsChartModel {
 
     @observable startDate = moment().subtract(3, 'months').toDate();

--- a/admin/tabs/general/GeneralTab.js
+++ b/admin/tabs/general/GeneralTab.js
@@ -14,7 +14,7 @@ import {ServicePanel} from './services/ServicePanel';
 import {EhCachePanel} from './ehcache/EhCachePanel';
 import {UserPanel} from './users/UserPanel';
 
-@HoistComponent()
+@HoistComponent
 export class GeneralTab extends Component {
 
     localModel = new TabContainerModel({

--- a/admin/tabs/general/about/AboutPanel.js
+++ b/admin/tabs/general/about/AboutPanel.js
@@ -11,7 +11,7 @@ import {div, h1, h2, table, tbody, tr, th, td} from '@xh/hoist/cmp/layout';
 
 import './AboutPanel.scss';
 
-@HoistComponent()
+@HoistComponent
 export class AboutPanel extends Component {
 
     render() {

--- a/admin/tabs/general/configs/ConfigPanel.js
+++ b/admin/tabs/general/configs/ConfigPanel.js
@@ -15,7 +15,7 @@ import {Icon} from '@xh/hoist/icon';
 import {configDiffer} from './differ/ConfigDiffer';
 import {ConfigDifferModel} from './differ/ConfigDifferModel';
 
-@HoistComponent()
+@HoistComponent
 export class ConfigPanel extends Component {
 
     gridModel = new RestGridModel({

--- a/admin/tabs/general/configs/differ/ConfigDiffer.js
+++ b/admin/tabs/general/configs/differ/ConfigDiffer.js
@@ -19,7 +19,7 @@ import {configDifferDetail} from './ConfigDifferDetail';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ConfigDiffer extends Component {
 
     render() {

--- a/admin/tabs/general/configs/differ/ConfigDifferDetail.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferDetail.js
@@ -19,7 +19,7 @@ import './Differ.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ConfigDifferDetail extends Component {
 
     render() {

--- a/admin/tabs/general/configs/differ/ConfigDifferDetailModel.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferDetailModel.js
@@ -11,7 +11,7 @@ import {action, observable} from '@xh/hoist/mobx';
 /**
  * @private
  */
-@HoistModel()
+@HoistModel
 export class ConfigDifferDetailModel  {
 
     parent = null;

--- a/admin/tabs/general/configs/differ/ConfigDifferModel.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferModel.js
@@ -21,7 +21,7 @@ import {ConfigDifferDetailModel} from './ConfigDifferDetailModel';
 /**
  * @private
  */
-@HoistModel()
+@HoistModel
 export class ConfigDifferModel  {
 
     detailModel = new ConfigDifferDetailModel({parent: this});

--- a/admin/tabs/general/ehcache/EhCacheModel.js
+++ b/admin/tabs/general/ehcache/EhCacheModel.js
@@ -11,7 +11,7 @@ import {UrlStore} from '@xh/hoist/data';
 import {emptyFlexCol, numberCol} from '@xh/hoist/columns';
 
 
-@HoistModel()
+@HoistModel
 export class EhCacheModel {
 
     gridModel = new GridModel({

--- a/admin/tabs/general/ehcache/EhCachePanel.js
+++ b/admin/tabs/general/ehcache/EhCachePanel.js
@@ -16,7 +16,7 @@ import {Icon} from '@xh/hoist/icon';
 
 import {EhCacheModel} from './EhCacheModel';
 
-@HoistComponent()
+@HoistComponent
 export class EhCachePanel extends Component {
 
     localModel = new EhCacheModel();

--- a/admin/tabs/general/services/ServiceModel.js
+++ b/admin/tabs/general/services/ServiceModel.js
@@ -8,7 +8,7 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {UrlStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/desktop/cmp/grid';
 
-@HoistModel()
+@HoistModel
 export class ServiceModel {
 
     gridModel = new GridModel({

--- a/admin/tabs/general/services/ServicePanel.js
+++ b/admin/tabs/general/services/ServicePanel.js
@@ -15,7 +15,7 @@ import {storeCountLabel, storeFilterField} from '@xh/hoist/desktop/cmp/store';
 import {Icon} from '@xh/hoist/icon';
 import {ServiceModel} from './ServiceModel';
 
-@HoistComponent()
+@HoistComponent
 export class ServicePanel extends Component {
 
     localModel = new ServiceModel();

--- a/admin/tabs/general/users/UserModel.js
+++ b/admin/tabs/general/users/UserModel.js
@@ -11,7 +11,7 @@ import {GridModel} from '@xh/hoist/desktop/cmp/grid';
 import {boolCheckCol} from '@xh/hoist/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 
-@HoistModel()
+@HoistModel
 export class UserModel {
 
     gridModel = new GridModel({

--- a/admin/tabs/general/users/UserPanel.js
+++ b/admin/tabs/general/users/UserPanel.js
@@ -15,7 +15,7 @@ import {storeCountLabel, storeFilterField} from '@xh/hoist/desktop/cmp/store';
 
 import {UserModel} from './UserModel';
 
-@HoistComponent()
+@HoistComponent
 export class UserPanel extends Component {
 
     localModel = new UserModel();

--- a/admin/tabs/logging/LogLevelPanel.js
+++ b/admin/tabs/logging/LogLevelPanel.js
@@ -9,7 +9,7 @@ import {HoistComponent} from '@xh/hoist/core';
 import {restGrid, RestGridModel, RestStore} from '@xh/hoist/desktop/cmp/rest';
 import {emptyFlexCol} from '@xh/hoist/columns';
 
-@HoistComponent()
+@HoistComponent
 export class LogLevelPanel extends Component {
 
     localModel = new RestGridModel({

--- a/admin/tabs/logging/LoggingTab.js
+++ b/admin/tabs/logging/LoggingTab.js
@@ -11,7 +11,7 @@ import {tabContainer, TabContainerModel} from '@xh/hoist/desktop/cmp/tab';
 import {LogLevelPanel} from './LogLevelPanel';
 import {LogViewer} from './viewer/LogViewer';
 
-@HoistComponent()
+@HoistComponent
 export class LoggingTab extends Component {
 
     localModel = new TabContainerModel({

--- a/admin/tabs/logging/viewer/LogViewer.js
+++ b/admin/tabs/logging/viewer/LogViewer.js
@@ -21,7 +21,7 @@ import './LogViewer.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LogViewer extends Component {
     localModel = new LogViewerModel();
 

--- a/admin/tabs/logging/viewer/LogViewerDisplay.js
+++ b/admin/tabs/logging/viewer/LogViewerDisplay.js
@@ -17,7 +17,7 @@ import {Timer} from '@xh/hoist/utils/async';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 @ContextMenuSupport
 export class LogViewerDisplay extends Component {
 

--- a/admin/tabs/logging/viewer/LogViewerModel.js
+++ b/admin/tabs/logging/viewer/LogViewerModel.js
@@ -15,7 +15,7 @@ import {PanelSizingModel} from '@xh/hoist/desktop/cmp/panel';
 /**
  * @private
  */
-@HoistModel()
+@HoistModel
 export class LogViewerModel {
 
     // Form State/Display options

--- a/admin/tabs/logging/viewer/LogViewerToolbar.js
+++ b/admin/tabs/logging/viewer/LogViewerToolbar.js
@@ -15,7 +15,7 @@ import {Icon} from '@xh/hoist/icon';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LogViewerToolbar extends Component {
     
     render() {

--- a/admin/tabs/monitor/MonitorEditorPanel.js
+++ b/admin/tabs/monitor/MonitorEditorPanel.js
@@ -9,7 +9,7 @@ import {HoistComponent} from '@xh/hoist/core';
 import {boolCheckCol, numberCol} from '@xh/hoist/columns';
 import {restGrid, RestGridModel, RestStore} from '@xh/hoist/desktop/cmp/rest';
 
-@HoistComponent()
+@HoistComponent
 export class MonitorEditorPanel extends Component {
 
     localModel = new RestGridModel({

--- a/admin/tabs/monitor/MonitorResultsDisplay.js
+++ b/admin/tabs/monitor/MonitorResultsDisplay.js
@@ -12,7 +12,7 @@ import {tile} from './Tile';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class MonitorResultsDisplay extends Component {
     render() {
         const {results} = this.model;

--- a/admin/tabs/monitor/MonitorResultsModel.js
+++ b/admin/tabs/monitor/MonitorResultsModel.js
@@ -11,7 +11,7 @@ import {action, observable, computed} from '@xh/hoist/mobx';
 import {min} from 'lodash';
 import {Timer} from '@xh/hoist/utils/async';
 
-@HoistModel()
+@HoistModel
 export class MonitorResultsModel {
     @observable.ref results = [];
     @observable lastRun = null;

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -15,7 +15,7 @@ import {MonitorResultsModel} from './MonitorResultsModel';
 import './MonitorResultsPanel.scss';
 
 
-@HoistComponent()
+@HoistComponent
 export class MonitorResultsPanel extends Component {
     localModel = new MonitorResultsModel({view: this});
 

--- a/admin/tabs/monitor/MonitorResultsToolbar.js
+++ b/admin/tabs/monitor/MonitorResultsToolbar.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class MonitorResultsToolbar extends Component {
     render() {
         const {passed, warned, failed, forceRunAllMonitors, lastRun} = this.model;

--- a/admin/tabs/monitor/MonitorTab.js
+++ b/admin/tabs/monitor/MonitorTab.js
@@ -11,7 +11,7 @@ import {tabContainer, TabContainerModel} from '@xh/hoist/desktop/cmp/tab';
 import {MonitorResultsPanel} from './MonitorResultsPanel';
 import {MonitorEditorPanel} from './MonitorEditorPanel';
 
-@HoistComponent()
+@HoistComponent
 export class MonitorTab extends Component {
 
     localModel = new TabContainerModel({

--- a/admin/tabs/monitor/Tile.js
+++ b/admin/tabs/monitor/Tile.js
@@ -17,7 +17,7 @@ import './Tile.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Tile extends Component {
     render() {
         const {checksInStatus, lastStatusChanged, metric, metricUnit, message, name, status} = this.props.check,

--- a/admin/tabs/preferences/PreferencePanel.js
+++ b/admin/tabs/preferences/PreferencePanel.js
@@ -9,7 +9,7 @@ import {HoistComponent} from '@xh/hoist/core';
 import {restGrid, RestGridModel, RestStore} from '@xh/hoist/desktop/cmp/rest';
 import {boolCheckCol} from '@xh/hoist/columns';
 
-@HoistComponent()
+@HoistComponent
 export class PreferencePanel extends Component {
 
     localModel = new RestGridModel({

--- a/admin/tabs/preferences/PreferencesTab.js
+++ b/admin/tabs/preferences/PreferencesTab.js
@@ -12,7 +12,7 @@ import {PreferencePanel} from './PreferencePanel';
 import {UserPreferencePanel} from './UserPreferencePanel';
 
 
-@HoistComponent()
+@HoistComponent
 export class PreferencesTab extends Component {
 
     localModel = new TabContainerModel({

--- a/admin/tabs/preferences/UserPreferencePanel.js
+++ b/admin/tabs/preferences/UserPreferencePanel.js
@@ -9,7 +9,7 @@ import {HoistComponent} from '@xh/hoist/core';
 import {restGrid, RestGridModel, RestStore} from '@xh/hoist/desktop/cmp/rest';
 import {usernameCol} from '@xh/hoist/admin/columns';
 
-@HoistComponent()
+@HoistComponent
 export class UserPreferencePanel extends Component {
 
     localModel = new RestGridModel({

--- a/cmp/layout/Box.js
+++ b/cmp/layout/Box.js
@@ -17,7 +17,7 @@ import {div} from './Tags';
  *
  * VBox and HBox variants support internal vertical (column) and horizontal (row) flex layouts.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Box extends Component {
     render() {
@@ -35,7 +35,7 @@ export class Box extends Component {
     }
 }
 
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class VBox extends Component {
     baseClassName = 'xh-vbox';
@@ -48,7 +48,7 @@ export class VBox extends Component {
     }
 }
 
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class HBox extends Component {
     baseClassName = 'xh-hbox';

--- a/cmp/layout/Frame.js
+++ b/cmp/layout/Frame.js
@@ -15,7 +15,7 @@ import {box} from './Box';
  *
  * VFrame and HFrame variants support internal vertical (column) and horizontal (row) flex layouts.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Frame extends Component {
     render() {
@@ -26,7 +26,7 @@ export class Frame extends Component {
     }
 }
 
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class VFrame extends Component {
     baseClassName = 'xh-vframe';
@@ -40,7 +40,7 @@ export class VFrame extends Component {
     }
 }
 
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class HFrame extends Component {
     baseClassName = 'xh-hframe';

--- a/cmp/layout/Spacer.js
+++ b/cmp/layout/Spacer.js
@@ -13,7 +13,7 @@ import {box} from './Box';
  * A component for inserting a fixed-sized spacer along the main axis of its parent container.
  * Convenience ElemFactories hspacer() and vspacer() each take a pixel size directly.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Spacer extends Component {
     baseClassName = 'xh-spacer';
@@ -29,7 +29,7 @@ export class Spacer extends Component {
 /**
  * A component that stretches to soak up space along the main axis of its parent container.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Filler extends Component {
     baseClassName = 'xh-filler';

--- a/cmp/layout/Viewport.js
+++ b/cmp/layout/Viewport.js
@@ -13,7 +13,7 @@ import {box} from './Box';
  * A container for the top level of the application.
  * Will stretch to encompass the entire browser.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Viewport extends Component {
     baseClassName = 'xh-viewport';

--- a/cmp/relativetimestamp/RelativeTimestamp.js
+++ b/cmp/relativetimestamp/RelativeTimestamp.js
@@ -44,7 +44,7 @@ const defaultOptions = {
  * Displays the approximate amount of time between a given timestamp and the present moment
  * in a friendly, human readable form. Automatically updates on a regular interval to stay current.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class RelativeTimestamp extends Component {
 

--- a/core/HoistApp.js
+++ b/core/HoistApp.js
@@ -22,7 +22,7 @@ import {HoistModel} from './HoistModel';
 export function HoistApp(C) {
     markClass(C, 'isHoistApp');
 
-    C = HoistModel()(C);
+    C = HoistModel(C);
 
     defaultMethods(C, {
 

--- a/core/HoistComponent.js
+++ b/core/HoistComponent.js
@@ -21,99 +21,89 @@ import {elemFactory} from './elem';
  * negatively impacted by the overhead associated with this decorator.
  *
  * Adds support for managed events, mobx reactivity, model awareness, and other convenience getters.
- *
- * @param {Object} [config] - configuration for the decorator.
- * @param {boolean} [config.isReactive] - apply the ReactiveSupport and mobX Observer mixins to the component Class.
  */
-export function HoistComponent({isReactive = true} = {}) {
+export function HoistComponent(C) {
 
-    return (C) => {
-        markClass(C, 'isHoistComponent');
+    markClass(C, 'isHoistComponent');
 
-        if (isReactive) {
-            C = ReactiveSupport(C);
-        }
+    C = ReactiveSupport(C);
 
-        
-        defaultMethods(C, {
-            /**
-             * Model class which this component is rendering.  This is a shortcut getter
-             * for either a 'localModel' property on the component or a 'model' placed in props.
-             */
-            model: {
-                get() {return this.localModel ? this.localModel : this.props.model}
-            },
+    defaultMethods(C, {
+        /**
+         * Model class which this component is rendering.  This is a shortcut getter
+         * for either a 'localModel' property on the component or a 'model' placed in props.
+         */
+        model: {
+            get() {return this.localModel ? this.localModel : this.props.model}
+        },
 
 
-            /**
-             * Is this component in the DOM and not within a hidden sub-tree (e.g. hidden tab).
-             * Based on the underlying css 'display' property of all ancestor properties.
-             */
-            isDisplayed: {
-                get() {
-                    let elem = this.getDOMNode();
-                    if (!elem) return false;
-                    while (elem) {
-                        if (elem.style.display == 'none') return false;
-                        elem = elem.parentElement;
-                    }
-                    return true;
+        /**
+         * Is this component in the DOM and not within a hidden sub-tree (e.g. hidden tab).
+         * Based on the underlying css 'display' property of all ancestor properties.
+         */
+        isDisplayed: {
+            get() {
+                let elem = this.getDOMNode();
+                if (!elem) return false;
+                while (elem) {
+                    if (elem.style.display == 'none') return false;
+                    elem = elem.parentElement;
                 }
-            },
-
-            /**
-             * Get the DOM element underlying this component.
-             * Returns null if component is not mounted.
-             */
-            getDOMNode() {
-                return this._mounted ? ReactDom.findDOMNode(this) : null;
-            },
-
-            /**
-             * Concatenate a CSS baseClassName (if defined on component) with any instance-specific
-             * className provided via props and optional extra names provided at render-time.
-             *
-             * Components should call this to produce a combined class list and apply it to their
-             * outermost (or otherwise most appropriate) rendered component.
-             *
-             * @param {...string} extraClassNames - additional classNames to append.
-             */
-            getClassName(...extraClassNames) {
-                return classNames(this.baseClassName, this.props.className, ...extraClassNames);
+                return true;
             }
-        });
+        },
 
+        /**
+         * Get the DOM element underlying this component.
+         * Returns null if component is not mounted.
+         */
+        getDOMNode() {
+            return this._mounted ? ReactDom.findDOMNode(this) : null;
+        },
 
-        //--------------------------
-        // Implementation
-        //--------------------------
-        chainMethods(C, {
-            componentDidMount() {
-                this._mounted = true;
-            },
-
-            componentWillUnmount() {
-                this._mounted = false;
-                this.destroy();
-            },
-
-            destroy() {
-                XH.safeDestroy(this.localModel);
-            }
-        });
-
-        // This must be last, should provide the last override of render
-        if (isReactive) {
-            C = observer(C);
+        /**
+         * Concatenate a CSS baseClassName (if defined on component) with any instance-specific
+         * className provided via props and optional extra names provided at render-time.
+         *
+         * Components should call this to produce a combined class list and apply it to their
+         * outermost (or otherwise most appropriate) rendered component.
+         *
+         * @param {...string} extraClassNames - additional classNames to append.
+         */
+        getClassName(...extraClassNames) {
+            return classNames(this.baseClassName, this.props.className, ...extraClassNames);
         }
+    });
 
-        return C;
-    };
+
+    //--------------------------
+    // Implementation
+    //--------------------------
+    chainMethods(C, {
+        componentDidMount() {
+            this._mounted = true;
+        },
+
+        componentWillUnmount() {
+            this._mounted = false;
+            this.destroy();
+        },
+
+        destroy() {
+            XH.safeDestroy(this.localModel);
+        }
+    });
+
+    // This must be last, should provide the last override of render
+    C = observer(C);
+    
+    return C;
 }
 
 /**
  * Create an elementFactory for a HoistComponent.
  */
-export function hoistComponentFactory(C, hcArgs = {}) {
-    return elemFactory(HoistComponent(hcArgs)(C));
+export function hoistComponentFactory(C) {
+    return elemFactory(HoistComponent(C));
 }

--- a/core/HoistModel.js
+++ b/core/HoistModel.js
@@ -15,14 +15,11 @@ import {markClass} from '@xh/hoist/utils/js';
  * All State models in Hoist applications should typically be decorated with this function.
  * Adds support for managed events and mobx reactivity.
  */
-export function HoistModel() {
+export function HoistModel(C) {
+    markClass(C, 'isHoistModel');
 
-    return (C) => {
-        markClass(C, 'isHoistModel');
+    C = EventSupport(C);
+    C = ReactiveSupport(C);
 
-        C = EventSupport(C);
-        C = ReactiveSupport(C);
-        
-        return C;
-    };
+    return C;
 }

--- a/core/HoistService.js
+++ b/core/HoistService.js
@@ -18,25 +18,23 @@ import {ReactiveSupport} from './mixins/ReactiveSupport';
  * All services Hoist applications should typically be decorated with this function.
  * Adds support for managed events, mobx reactivity, and lifecycle initialization.
  */
-export function HoistService() {
+export function HoistService(C) {
 
-    return (C) => {
-        markClass(C, 'isHoistService');
+    markClass(C, 'isHoistService');
 
-        C = EventSupport(C);
-        C = ReactiveSupport(C);
+    C = EventSupport(C);
+    C = ReactiveSupport(C);
 
-        defaultMethods(C, {
-            /**
-             * Called by framework or application to initialize before application startup.
-             * Throwing an exception from this method will typically block startup.
-             * Service writers should take care to stifle and manage all non-fatal exceptions.
-             */
-            async initAsync() {}
-        });
+    defaultMethods(C, {
+        /**
+         * Called by framework or application to initialize before application startup.
+         * Throwing an exception from this method will typically block startup.
+         * Service writers should take care to stifle and manage all non-fatal exceptions.
+         */
+        async initAsync() {}
+    });
 
-        return C;
-    };
+    return C;
 }
 
 

--- a/core/RouterModel.js
+++ b/core/RouterModel.js
@@ -16,7 +16,7 @@ import browserPlugin from 'router5/plugins/browser';
  * This observable model uses Router5 (https://router5.js.org/) to manage the
  * underlying routes, presenting them to the application as a set of MobX observables.
  */
-@HoistModel()
+@HoistModel
 export class RouterModel {
 
     /** Router5 state object representing the current state. */

--- a/core/XH.js
+++ b/core/XH.js
@@ -44,7 +44,7 @@ import '../styles/XH.scss';
  *
  * Available via import as `XH` - also installed as `window.XH` for troubleshooting purposes.
  */
-@HoistModel()
+@HoistModel
 class XHClass {
 
     //------------------------------------------------------------------

--- a/core/appcontainer/AboutDialogModel.js
+++ b/core/appcontainer/AboutDialogModel.js
@@ -12,7 +12,7 @@ import {table, tbody, tr, th, td} from '@xh/hoist/cmp/layout';
  * Support for About Dialog.
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class AboutDialogModel {
 
     @observable isOpen = false;

--- a/core/appcontainer/AppContainerModel.js
+++ b/core/appcontainer/AppContainerModel.js
@@ -20,7 +20,7 @@ import {ThemeModel} from './ThemeModel';
 /**
  *  Root object for Framework GUI State.
  */
-@HoistModel()
+@HoistModel
 export class AppContainerModel {
 
     //------------

--- a/core/appcontainer/ExceptionDialogModel.js
+++ b/core/appcontainer/ExceptionDialogModel.js
@@ -15,7 +15,7 @@ import {observable, action} from '@xh/hoist/mobx';
  *
  * @private
  */
-@HoistModel()
+@HoistModel
 export class ExceptionDialogModel {
 
     @observable.ref displayData;

--- a/core/appcontainer/FeedbackDialogModel.js
+++ b/core/appcontainer/FeedbackDialogModel.js
@@ -12,7 +12,7 @@ import {observable, action} from '@xh/hoist/mobx';
  * Manages built-in collection of user feedback.
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class FeedbackDialogModel {
 
     @observable isOpen = false;

--- a/core/appcontainer/ImpersonationBarModel.js
+++ b/core/appcontainer/ImpersonationBarModel.js
@@ -14,7 +14,7 @@ import {throwIf} from '@xh/hoist/utils/js';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class ImpersonationBarModel {
 
     @observable showRequested = false;

--- a/core/appcontainer/LoginPanelModel.js
+++ b/core/appcontainer/LoginPanelModel.js
@@ -12,7 +12,7 @@ import {observable, computed, action} from '@xh/hoist/mobx';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class LoginPanelModel {
 
     @observable username = '';

--- a/core/appcontainer/MessageModel.js
+++ b/core/appcontainer/MessageModel.js
@@ -12,7 +12,7 @@ import {HoistModel} from '@xh/hoist/core';
  *
  * @private
  */
-@HoistModel()
+@HoistModel
 export class MessageModel {
 
     // Immutable properties

--- a/core/appcontainer/MessageSourceModel.js
+++ b/core/appcontainer/MessageSourceModel.js
@@ -16,7 +16,7 @@ import {MessageModel} from './MessageModel';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class MessageSourceModel {
 
     @observable.ref msgModels = [];

--- a/core/appcontainer/ThemeModel.js
+++ b/core/appcontainer/ThemeModel.js
@@ -13,7 +13,7 @@ import {observable, action} from '@xh/hoist/mobx';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class ThemeModel {
 
     @observable darkTheme = false;

--- a/core/appcontainer/ToastModel.js
+++ b/core/appcontainer/ToastModel.js
@@ -15,7 +15,7 @@ import {SECONDS} from '@xh/hoist/utils/datetime';
  *
  * @private
  */
-@HoistModel()
+@HoistModel
 export class ToastModel {
 
     // Immutable public properties

--- a/core/appcontainer/ToastSourceModel.js
+++ b/core/appcontainer/ToastSourceModel.js
@@ -13,7 +13,7 @@ import {ToastModel} from './ToastModel';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class ToastSourceModel {
 
     @observable.ref toastModels = [];

--- a/data/StoreSelectionModel.js
+++ b/data/StoreSelectionModel.js
@@ -12,7 +12,7 @@ import {castArray, intersection, union} from 'lodash';
 /**
  * Model for managing store selections.
  */
-@HoistModel()
+@HoistModel
 export class StoreSelectionModel {
 
     store = null;

--- a/desktop/appcontainer/AboutDialog.js
+++ b/desktop/appcontainer/AboutDialog.js
@@ -22,7 +22,7 @@ import './AboutDialog.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class AboutDialog extends Component {
 
     render() {

--- a/desktop/appcontainer/AppContainer.js
+++ b/desktop/appcontainer/AppContainer.js
@@ -32,7 +32,7 @@ import {ToastSource} from './ToastSource';
  * impersonation bar header, version bar footer, an app-wide load mask, a base context menu,
  * popup message support, and exception rendering.
  */
-@HoistComponent()
+@HoistComponent
 export class AppContainer extends Component {
 
     @observable.ref caughtException = null;

--- a/desktop/appcontainer/ExceptionDialog.js
+++ b/desktop/appcontainer/ExceptionDialog.js
@@ -21,7 +21,7 @@ import {exceptionDialogDetails} from './ExceptionDialogDetails';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ExceptionDialog extends Component {
 
     render() {

--- a/desktop/appcontainer/ExceptionDialogDetails.js
+++ b/desktop/appcontainer/ExceptionDialogDetails.js
@@ -22,7 +22,7 @@ import {dismissButton} from './ExceptionDialog';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ExceptionDialogDetails extends Component {
 
     render() {

--- a/desktop/appcontainer/FeedbackDialog.js
+++ b/desktop/appcontainer/FeedbackDialog.js
@@ -18,7 +18,7 @@ import {button} from '@xh/hoist/desktop/cmp/button';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class FeedbackDialog extends Component {
 
     render() {

--- a/desktop/appcontainer/ImpersonationBar.js
+++ b/desktop/appcontainer/ImpersonationBar.js
@@ -21,7 +21,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 @HotkeysTarget
 export class ImpersonationBar extends Component {
 

--- a/desktop/appcontainer/LockoutPanel.js
+++ b/desktop/appcontainer/LockoutPanel.js
@@ -18,7 +18,7 @@ import {impersonationBar} from './ImpersonationBar';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LockoutPanel extends Component {
 
     render() {

--- a/desktop/appcontainer/LoginPanel.js
+++ b/desktop/appcontainer/LoginPanel.js
@@ -23,7 +23,7 @@ import './LoginPanel.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LoginPanel extends Component {
 
     render() {

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -16,7 +16,7 @@ import {button} from '@xh/hoist/desktop/cmp/button';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Message extends Component {
 
     render() {

--- a/desktop/appcontainer/MessageSource.js
+++ b/desktop/appcontainer/MessageSource.js
@@ -14,7 +14,7 @@ import {message} from './Message';
  *
  *  @private
  */
-@HoistComponent()
+@HoistComponent
 export class MessageSource extends Component {
     render() {
         const models = this.model.msgModels,

--- a/desktop/appcontainer/SuspendedDialog.js
+++ b/desktop/appcontainer/SuspendedDialog.js
@@ -19,7 +19,7 @@ import {message} from './Message';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class SuspendedDialog extends Component {
 
     localModel = new MessageModel({

--- a/desktop/appcontainer/ToastSource.js
+++ b/desktop/appcontainer/ToastSource.js
@@ -14,7 +14,7 @@ import {Position, Toaster} from '@xh/hoist/kit/blueprint';
  *
  *  @private
  */
-@HoistModel()
+@HoistModel
 export class ToastSource {
 
     _toasters = {};

--- a/desktop/appcontainer/UpdateBar.js
+++ b/desktop/appcontainer/UpdateBar.js
@@ -15,7 +15,7 @@ import './UpdateBar.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class UpdateBar extends Component {
 
     render() {

--- a/desktop/appcontainer/VersionBar.js
+++ b/desktop/appcontainer/VersionBar.js
@@ -14,7 +14,7 @@ import './VersionBar.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class VersionBar extends Component {
 
     render() {

--- a/desktop/cmp/appbar/AppBar.js
+++ b/desktop/cmp/appbar/AppBar.js
@@ -23,7 +23,7 @@ import './AppBar.scss';
  * The standard buttons which are visible will be based on user roles and application configuration,
  * or they can each be explicitly hidden.
  */
-@HoistComponent()
+@HoistComponent
 export class AppBar extends Component {
     static propTypes = {
         /** Icon to display before the title. */

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -14,7 +14,7 @@ import {button as bpButton} from '@xh/hoist/kit/blueprint';
  * Wrapper around Blueprint's Button component.
  * Hoist's most basic button accepts any props supported by Blueprint's Button.
  */
-@HoistComponent()
+@HoistComponent
 export class Button extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/ExportButton.js
+++ b/desktop/cmp/button/ExportButton.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
  * Must be provided either an onClick handler *or* a model. If a model is provided, this button
  * will call export() on the model class.
  */
-@HoistComponent()
+@HoistComponent
 export class ExportButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/FeedbackButton.js
+++ b/desktop/cmp/button/FeedbackButton.js
@@ -16,7 +16,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * Can be provided an onClick handler, otherwise will call default framework handler.
  */
-@HoistComponent()
+@HoistComponent
 export class FeedbackButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/LaunchAdminButton.js
+++ b/desktop/cmp/button/LaunchAdminButton.js
@@ -14,7 +14,7 @@ import {button} from '@xh/hoist/kit/blueprint';
  * Convenience Button to open the admin client.
  * Visible only to users with the hoistAdmin application role.
  */
-@HoistComponent()
+@HoistComponent
 export class LaunchAdminButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/LogoutButton.js
+++ b/desktop/cmp/button/LogoutButton.js
@@ -17,7 +17,7 @@ import {button} from '@xh/hoist/kit/blueprint';
  * An onClick handler can be provided to implement additional operations on logout,
  * but should ensure it calls `XH.identityService.logoutAsync()`.
  */
-@HoistComponent()
+@HoistComponent
 export class LogoutButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/RefreshButton.js
+++ b/desktop/cmp/button/RefreshButton.js
@@ -18,7 +18,7 @@ import {warnIf} from '@xh/hoist/utils/js';
  * Must be provided either an onClick handler *or* a model. If a model is provided and an onClick
  * handler is not provided, this button will call loadAsync() on the model class.
  */
-@HoistComponent()
+@HoistComponent
 export class RefreshButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/RestoreDefaultsButton.js
+++ b/desktop/cmp/button/RestoreDefaultsButton.js
@@ -18,7 +18,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * Can be provided an onClick handler, otherwise will call default framework handler.
  */
-@HoistComponent()
+@HoistComponent
 export class RestoreDefaultsButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/button/ThemeToggleButton.js
+++ b/desktop/cmp/button/ThemeToggleButton.js
@@ -14,7 +14,7 @@ import {button, HotkeysTarget, hotkeys, hotkey} from '@xh/hoist/kit/blueprint';
  * Convenience Button preconfigured for use as a trigger for light/dark theme toggling.
  * Theme can also be toggled via a global Shift+t keyboard shortcut.
  */
-@HoistComponent()
+@HoistComponent
 @HotkeysTarget
 export class ThemeToggleButton extends Component {
 

--- a/desktop/cmp/chart/Chart.js
+++ b/desktop/cmp/chart/Chart.js
@@ -20,7 +20,7 @@ import {DarkTheme} from './theme/Dark';
  * as well as configuration and theme defaults. The chart's core configuration should be sourced
  * from a ChartModel prop passed to this component.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Chart extends Component {
 

--- a/desktop/cmp/chart/ChartModel.js
+++ b/desktop/cmp/chart/ChartModel.js
@@ -11,7 +11,7 @@ import {observable, action} from '@xh/hoist/mobx';
 /**
  * Model to hold and maintain the configuration and data series for a Highcharts chart.
  */
-@HoistModel()
+@HoistModel
 export class ChartModel {
 
     @observable.ref config = {};

--- a/desktop/cmp/clipboard/ClipboardButton.js
+++ b/desktop/cmp/clipboard/ClipboardButton.js
@@ -15,7 +15,7 @@ import ClipboardJS from 'clipboard';
 /**
  * Button to copy text to the clipboard - via the clipboard.js library (https://clipboardjs.com).
  */
-@HoistComponent()
+@HoistComponent
 export class ClipboardButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/clipboard/ClipboardMenuItem.js
+++ b/desktop/cmp/clipboard/ClipboardMenuItem.js
@@ -15,7 +15,7 @@ import {Icon} from '@xh/hoist/icon';
 /**
  * Convenience wrapper for a ClipboardButton to be rendered as a Blueprint menu item.
  */
-@HoistComponent()
+@HoistComponent
 export class ClipboardMenuItem extends Component {
 
     static propTypes = {

--- a/desktop/cmp/dataview/DataView.js
+++ b/desktop/cmp/dataview/DataView.js
@@ -15,7 +15,7 @@ import {grid, GridModel} from '@xh/hoist/desktop/cmp/grid';
  *
  * @see DataViewModel
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class DataView extends Component {
 

--- a/desktop/cmp/dataview/DataViewModel.js
+++ b/desktop/cmp/dataview/DataViewModel.js
@@ -16,7 +16,7 @@ import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
  *
  * This is the primary application entry-point for specifying DataView component options and behavior.
  */
-@HoistModel()
+@HoistModel
 export class DataViewModel {
 
     // Immutable public properties

--- a/desktop/cmp/form/CheckField.js
+++ b/desktop/cmp/form/CheckField.js
@@ -15,7 +15,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  * CheckBox Field.
  * Note that this field does not handle null values. For nullable fields, use a SelectField.
  */
-@HoistComponent()
+@HoistComponent
 export class CheckField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/DayField.js
+++ b/desktop/cmp/form/DayField.js
@@ -21,7 +21,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class DayField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/JsonField.js
+++ b/desktop/cmp/form/JsonField.js
@@ -28,7 +28,7 @@ import './JsonField.scss';
 /**
  * A field for editing and validating JSON, providing a mini-IDE style editor powered by CodeMirror.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class JsonField extends HoistField {
 

--- a/desktop/cmp/form/Label.js
+++ b/desktop/cmp/form/Label.js
@@ -14,7 +14,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
 /**
  * A simple label for a form.
  */
-@HoistComponent()
+@HoistComponent
 export class Label extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/NumberField.js
+++ b/desktop/cmp/form/NumberField.js
@@ -16,7 +16,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class NumberField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/SliderField.js
+++ b/desktop/cmp/form/SliderField.js
@@ -19,7 +19,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  *
  * Value can be either a single number (for a simple slider) or an array of 2 numbers (for a range)
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class SliderField extends HoistField {
 

--- a/desktop/cmp/form/SwitchField.js
+++ b/desktop/cmp/form/SwitchField.js
@@ -15,7 +15,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  * Switch Field. 
  * Note that that component does not handle null values. For nullable fields, use a SelectField.
  */
-@HoistComponent()
+@HoistComponent
 export class SwitchField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/TextAreaField.js
+++ b/desktop/cmp/form/TextAreaField.js
@@ -17,7 +17,7 @@ import './TextAreaField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class TextAreaField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/TextField.js
+++ b/desktop/cmp/form/TextField.js
@@ -16,7 +16,7 @@ import {HoistField} from '@xh/hoist/cmp/form';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class TextField extends HoistField {
 
     static propTypes = {

--- a/desktop/cmp/form/dropdown/ComboField.js
+++ b/desktop/cmp/form/dropdown/ComboField.js
@@ -15,7 +15,7 @@ import {BaseComboField} from './BaseComboField';
 /**
  * ComboBox Field - A field with type ahead suggest and menu select
  */
-@HoistComponent()
+@HoistComponent
 export class ComboField extends BaseComboField {
 
     static propTypes = {

--- a/desktop/cmp/form/dropdown/QueryComboField.js
+++ b/desktop/cmp/form/dropdown/QueryComboField.js
@@ -15,7 +15,7 @@ import {BaseComboField} from './BaseComboField';
 /**
  * ComboBox Field which populates its options dynamically based on the current value.
  */
-@HoistComponent()
+@HoistComponent
 export class QueryComboField extends BaseComboField {
     @observable.ref options = [];
 

--- a/desktop/cmp/form/dropdown/SelectField.js
+++ b/desktop/cmp/form/dropdown/SelectField.js
@@ -18,7 +18,7 @@ import './SelectField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class SelectField extends BaseDropdownField {
 
     static propTypes = {

--- a/desktop/cmp/grid/ColChooser.js
+++ b/desktop/cmp/grid/ColChooser.js
@@ -26,7 +26,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * It is not necessary to manually create instances of this component within an application.
  */
-@HoistComponent()
+@HoistComponent
 export class ColChooser extends Component {
 
     render() {

--- a/desktop/cmp/grid/ColChooserButton.js
+++ b/desktop/cmp/grid/ColChooserButton.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * Requires the `GridModel.enableColChooser` config option to be true.
  */
-@HoistComponent()
+@HoistComponent
 export class ColChooserButton extends Component {
 
     static propTypes = {

--- a/desktop/cmp/grid/ColChooserModel.js
+++ b/desktop/cmp/grid/ColChooserModel.js
@@ -14,7 +14,7 @@ import {LeftRightChooserModel} from '@xh/hoist/desktop/cmp/leftrightchooser';
  * It is not necessary to manually create instances of this class within an application.
  * @private
  */
-@HoistModel()
+@HoistModel
 export class ColChooserModel {
 
     gridModel = null;

--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -27,7 +27,7 @@ import {colChooser} from './ColChooser';
  * @see {@link https://www.ag-grid.com/javascript-grid-reference-overview/|ag-Grid Docs}
  * @see GridModel
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Grid extends Component {
 

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -35,7 +35,7 @@ import {ExportManager} from './ExportManager';
  *
  * This is the primary application entry-point for specifying Grid component options and behavior.
  */
-@HoistModel()
+@HoistModel
 export class GridModel {
 
     //------------------------

--- a/desktop/cmp/grid/GridStateModel.js
+++ b/desktop/cmp/grid/GridStateModel.js
@@ -18,7 +18,7 @@ import {start} from '@xh/hoist/promise';
  * It is not necessary to manually create instances of this class within an application.
  * @private
  */
-@HoistModel()
+@HoistModel
 export class GridStateModel {
 
     /**

--- a/desktop/cmp/leftrightchooser/LeftRightChooser.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooser.js
@@ -20,7 +20,7 @@ import './LeftRightChooser.scss';
  * A nested panel is also available to display a more in-depth description for any selected item.
  * @see LeftRightChooserModel
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class LeftRightChooser extends Component {
 

--- a/desktop/cmp/leftrightchooser/LeftRightChooserFilter.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserFilter.js
@@ -17,7 +17,7 @@ import {textField} from '@xh/hoist/desktop/cmp/form';
  * A Component that can bind to a LeftRightChooser and filter both lists
  * based on simple text matching in selected fields.
  */
-@HoistComponent()
+@HoistComponent
 export class LeftRightChooserFilter extends Component {
 
     static propTypes = {

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
@@ -13,7 +13,7 @@ import {convertIconToSvg, Icon} from '@xh/hoist/icon';
 /**
  * A Model for managing the state of a LeftRightChooser.
  */
-@HoistModel()
+@HoistModel
 export class LeftRightChooserModel {
     /**
      * Grid Model for the left-hand side.

--- a/desktop/cmp/leftrightchooser/impl/ChooserToolbar.js
+++ b/desktop/cmp/leftrightchooser/impl/ChooserToolbar.js
@@ -15,7 +15,7 @@ import {Icon} from '@xh/hoist/icon';
  * A Toolbar for the LeftRightChooser.
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ChooserToolbar extends Component {
 
     render() {

--- a/desktop/cmp/leftrightchooser/impl/Description.js
+++ b/desktop/cmp/leftrightchooser/impl/Description.js
@@ -12,7 +12,7 @@ import {callout} from '@xh/hoist/kit/blueprint';
  * Description panel for the LeftRightChooser.
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Description extends Component {
 
     render() {

--- a/desktop/cmp/mask/Mask.js
+++ b/desktop/cmp/mask/Mask.js
@@ -21,7 +21,7 @@ import './Mask.scss';
  *
  * The mask can be explicitly shown or reactively bound to a PendingTaskModel.
  */
-@HoistComponent()
+@HoistComponent
 export class Mask extends Component {
 
     static propTypes = {

--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -25,7 +25,7 @@ import './Panel.scss';
  * This component also includes support for resizing and collapsing its contents, if given a
  * PanelSizingModel.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class Panel extends Component {
 

--- a/desktop/cmp/panel/PanelSizingModel.js
+++ b/desktop/cmp/panel/PanelSizingModel.js
@@ -15,7 +15,7 @@ import {isNil} from 'lodash';
 /**
  * This class provides the underlying state for the resizing/collapse state of a Panel.
  */
-@HoistModel()
+@HoistModel
 export class PanelSizingModel {
 
     //-----------------------

--- a/desktop/cmp/panel/impl/Collapser.js
+++ b/desktop/cmp/panel/impl/Collapser.js
@@ -17,7 +17,7 @@ import './Collapser.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Collapser extends Component {
     
     render() {

--- a/desktop/cmp/panel/impl/Dragger.js
+++ b/desktop/cmp/panel/impl/Dragger.js
@@ -13,7 +13,7 @@ import './Dragger.scss';
 /** This is an implementation class private to Hoist
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Dragger extends Component {
 
     resizeState = null;

--- a/desktop/cmp/panel/impl/PanelHeader.js
+++ b/desktop/cmp/panel/impl/PanelHeader.js
@@ -14,7 +14,7 @@ import './PanelHeader.scss';
  * A standardized header for a Panel component
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class PanelHeader extends Component {
     render() {
         let {title, icon, headerItems = [], sizingModel} = this.props,

--- a/desktop/cmp/panel/impl/ResizeContainer.js
+++ b/desktop/cmp/panel/impl/ResizeContainer.js
@@ -16,7 +16,7 @@ import {collapser} from './Collapser';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ResizeContainer extends Component {
     
     baseClassName = 'xh-resizable';

--- a/desktop/cmp/rest/RestControl.js
+++ b/desktop/cmp/rest/RestControl.js
@@ -12,7 +12,7 @@ import {fmtDateTime} from '@xh/hoist/format';
 import {hbox} from '@xh/hoist/cmp/layout';
 import {label, checkField, comboField, jsonField, numberField, selectField, textAreaField, textField}  from '@xh/hoist/desktop/cmp/form';
 
-@HoistComponent()
+@HoistComponent
 export class RestControl extends Component {
 
     render() {

--- a/desktop/cmp/rest/RestControlModel.js
+++ b/desktop/cmp/rest/RestControlModel.js
@@ -9,7 +9,7 @@ import {HoistModel} from '@xh/hoist/core';
 import {computed} from '@xh/hoist/mobx';
 import {isJSON} from '@xh/hoist/utils/js';
 
-@HoistModel()
+@HoistModel
 export class RestControlModel  {
 
     field;

--- a/desktop/cmp/rest/RestForm.js
+++ b/desktop/cmp/rest/RestForm.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
 import {restControl} from './RestControl';
 import './RestForm.scss';
 
-@HoistComponent()
+@HoistComponent
 export class RestForm extends Component {
 
     baseClassName = 'xh-rest-form';

--- a/desktop/cmp/rest/RestFormModel.js
+++ b/desktop/cmp/rest/RestFormModel.js
@@ -13,7 +13,7 @@ import {isEqual} from 'lodash';
 
 import {RestControlModel} from './RestControlModel';
 
-@HoistModel()
+@HoistModel
 export class RestFormModel {
 
     parent = null;

--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -14,7 +14,7 @@ import {fragment} from '@xh/hoist/cmp/layout';
 import {restGridToolbar} from './RestGridToolbar';
 import {restForm} from './RestForm';
 
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class RestGrid extends Component {
 

--- a/desktop/cmp/rest/RestGridModel.js
+++ b/desktop/cmp/rest/RestGridModel.js
@@ -16,7 +16,7 @@ import {RestFormModel} from './RestFormModel';
 /**
  * Core Model for a RestGrid.
  */
-@HoistModel()
+@HoistModel
 export class RestGridModel {
 
     //----------------

--- a/desktop/cmp/rest/RestGridToolbar.js
+++ b/desktop/cmp/rest/RestGridToolbar.js
@@ -14,7 +14,7 @@ import {exportButton} from '@xh/hoist/desktop/cmp/button';
 import {storeCountLabel, storeFilterField} from '@xh/hoist/desktop/cmp/store';
 import {Icon} from '@xh/hoist/icon';
 
-@HoistComponent()
+@HoistComponent
 export class RestGridToolbar extends Component {
 
     render() {

--- a/desktop/cmp/store/StoreCountLabel.js
+++ b/desktop/cmp/store/StoreCountLabel.js
@@ -18,7 +18,7 @@ import {BaseStore} from '@xh/hoist/data';
  * A component to display the number of records in a given store.
  * Will auto-update with changes to the count, including store filtering.
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class StoreCountLabel extends Component {
 

--- a/desktop/cmp/store/StoreFilterField.js
+++ b/desktop/cmp/store/StoreFilterField.js
@@ -19,7 +19,7 @@ import {BaseStore} from '@xh/hoist/data';
  * A Component that can bind to any store and filter it
  * based on simple text matching in specified fields.
  */
-@HoistComponent()
+@HoistComponent
 export class StoreFilterField extends Component {
 
     static propTypes = {

--- a/desktop/cmp/tab/container/TabContainer.js
+++ b/desktop/cmp/tab/container/TabContainer.js
@@ -29,7 +29,7 @@ import '../Tabs.scss';
  *
  * @see TabContainerModel
  */
-@HoistComponent()
+@HoistComponent
 @LayoutSupport
 export class TabContainer extends Component {
 

--- a/desktop/cmp/tab/container/TabContainerModel.js
+++ b/desktop/cmp/tab/container/TabContainerModel.js
@@ -16,7 +16,7 @@ import {TabModel} from '@xh/hoist/desktop/cmp/tab';
  * This object provides support for routing based navigation, managed mounting/unmounting of
  * inactive tabs, and lazy refreshing of its active Tab.
  */
-@HoistModel()
+@HoistModel
 export class TabContainerModel {
 
     /**

--- a/desktop/cmp/tab/pane/Tab.js
+++ b/desktop/cmp/tab/pane/Tab.js
@@ -25,7 +25,7 @@ import {TabModel} from './TabModel';
  * Contained components that load data/state from the server should implement loadAsync(),
  * but generally leave the calling of that method to this component.
  */
-@HoistComponent()
+@HoistComponent
 export class Tab extends Component {
 
     static propTypes = {

--- a/desktop/cmp/tab/pane/TabModel.js
+++ b/desktop/cmp/tab/pane/TabModel.js
@@ -15,7 +15,7 @@ import {startCase} from 'lodash';
  * This model is not typically created directly within applications. Instead, specify a
  * configuration for it via the `TabContainerModel.tabs` constructor config.
  */
-@HoistModel()
+@HoistModel
 export class TabModel {
     id;
     title;

--- a/desktop/cmp/tab/switcher/TabSwitcher.js
+++ b/desktop/cmp/tab/switcher/TabSwitcher.js
@@ -20,7 +20,7 @@ import {omit} from 'lodash';
  *
  * @see TabContainer
  */
-@HoistComponent()
+@HoistComponent
 export class TabSwitcher extends Component {
     static propTypes = {
         /** TabContainerModel to be controlled. */

--- a/desktop/cmp/toolbar/Toolbar.js
+++ b/desktop/cmp/toolbar/Toolbar.js
@@ -15,7 +15,7 @@ import './Toolbar.scss';
  * A toolbar with built-in styling and padding.
  * Child items provided as raw configs will be created as buttons by default.
  */
-@HoistComponent()
+@HoistComponent
 export class Toolbar extends Component {
     static propTypes = {
         /** Custom classes that will be applied to this component */

--- a/desktop/cmp/toolbar/ToolbarSeparator.js
+++ b/desktop/cmp/toolbar/ToolbarSeparator.js
@@ -14,7 +14,7 @@ import './Toolbar.scss';
 /**
  * Convenience component to insert a pre-styled separator | between Toolbar items.
  */
-@HoistComponent()
+@HoistComponent
 export class ToolbarSeparator extends Component {
 
     baseClassName = 'xh-toolbar__separator';

--- a/field/Field.js
+++ b/field/Field.js
@@ -17,7 +17,7 @@ import {Rule} from './validation/Rule';
 /**
  * Maintains state relating to a property marked with `@field` decorator.
  */
-@HoistModel()
+@HoistModel
 export class Field {
 
     /** @member {string} name of property within model containing this field. */

--- a/field/impl/FieldsModel.js
+++ b/field/impl/FieldsModel.js
@@ -20,7 +20,7 @@ import {ValidationState} from '../validation/ValidationState';
  *
  * @private
  */
-@HoistModel()
+@HoistModel
 export class FieldsModel {
 
     _fields;

--- a/kit/blueprint/Dialog.js
+++ b/kit/blueprint/Dialog.js
@@ -12,7 +12,7 @@ import {div} from '@xh/hoist/cmp/layout';
 /**
  * Dialog Body for Blueprint, wrapped as HoistComponent.
  */
-@HoistComponent()
+@HoistComponent
 export class DialogBody extends Component {
     baseClassName = 'bp3-dialog-body';
     render() {
@@ -23,7 +23,7 @@ export class DialogBody extends Component {
 /**
  * Dialog Footer for Blueprint, wrapped as HoistComponent.
  */
-@HoistComponent()
+@HoistComponent
 export class DialogFooter extends Component {
     baseClassName = 'bp3-dialog-footer';
     render() {
@@ -34,7 +34,7 @@ export class DialogFooter extends Component {
 /**
  * Dialog Footer for Blueprint, wrapped as HoistComponent.
  */
-@HoistComponent()
+@HoistComponent
 export class DialogFooterActions extends Component {
     baseClassName = 'bp3-dialog-footer-actions';
     render() {

--- a/mobile/appcontainer/AboutDialog.js
+++ b/mobile/appcontainer/AboutDialog.js
@@ -19,7 +19,7 @@ import './AboutDialog.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class AboutDialog extends Component {
 
     render() {

--- a/mobile/appcontainer/AppContainer.js
+++ b/mobile/appcontainer/AppContainer.js
@@ -33,7 +33,7 @@ import {messageSource} from './MessageSource';
  *
  * @see HoistApp.containerClass
  */
-@HoistComponent()
+@HoistComponent
 export class AppContainer extends Component {
 
     @observable.ref caughtException = null;

--- a/mobile/appcontainer/ExceptionDialog.js
+++ b/mobile/appcontainer/ExceptionDialog.js
@@ -21,7 +21,7 @@ import {exceptionDialogDetails} from './ExceptionDialogDetails';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ExceptionDialog extends Component {
 
     render() {

--- a/mobile/appcontainer/ExceptionDialogDetails.js
+++ b/mobile/appcontainer/ExceptionDialogDetails.js
@@ -21,7 +21,7 @@ import {dismissButton} from './ExceptionDialog';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ExceptionDialogDetails extends Component {
 
     render() {

--- a/mobile/appcontainer/FeedbackDialog.js
+++ b/mobile/appcontainer/FeedbackDialog.js
@@ -17,7 +17,7 @@ import './FeedbackDialog.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class FeedbackDialog extends Component {
 
     render() {

--- a/mobile/appcontainer/ImpersonationBar.js
+++ b/mobile/appcontainer/ImpersonationBar.js
@@ -20,7 +20,7 @@ import './ImpersonationBar.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class ImpersonationBar extends Component {
 
     render() {

--- a/mobile/appcontainer/LockoutPanel.js
+++ b/mobile/appcontainer/LockoutPanel.js
@@ -20,7 +20,7 @@ import {impersonationBar} from './ImpersonationBar';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LockoutPanel extends Component {
 
     render() {

--- a/mobile/appcontainer/LoginPanel.js
+++ b/mobile/appcontainer/LoginPanel.js
@@ -21,7 +21,7 @@ import './LoginPanel.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class LoginPanel extends Component {
 
     render() {

--- a/mobile/appcontainer/Message.js
+++ b/mobile/appcontainer/Message.js
@@ -14,7 +14,7 @@ import {button} from '@xh/hoist/mobile/cmp/button';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 class Message extends Component {
 
     render() {

--- a/mobile/appcontainer/MessageSource.js
+++ b/mobile/appcontainer/MessageSource.js
@@ -14,7 +14,7 @@ import {message} from './Message';
  *
  *  @private
  */
-@HoistComponent()
+@HoistComponent
 export class MessageSource extends Component {
     render() {
         const models = this.model.msgModels,

--- a/mobile/appcontainer/Toast.js
+++ b/mobile/appcontainer/Toast.js
@@ -18,7 +18,7 @@ import './Toast.scss';
  *
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class Toast extends Component {
 
     render() {

--- a/mobile/appcontainer/ToastSource.js
+++ b/mobile/appcontainer/ToastSource.js
@@ -18,7 +18,7 @@ import {toast} from './Toast';
  *
  *  @private
  */
-@HoistComponent()
+@HoistComponent
 export class ToastSource extends Component {
 
     render() {

--- a/mobile/appcontainer/UpdateBar.js
+++ b/mobile/appcontainer/UpdateBar.js
@@ -14,7 +14,7 @@ import './UpdateBar.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class UpdateBar extends Component {
 
     render() {

--- a/mobile/appcontainer/VersionBar.js
+++ b/mobile/appcontainer/VersionBar.js
@@ -15,7 +15,7 @@ import './VersionBar.scss';
 /**
  * @private
  */
-@HoistComponent()
+@HoistComponent
 export class VersionBar extends Component {
 
     render() {

--- a/mobile/cmp/button/Button.js
+++ b/mobile/cmp/button/Button.js
@@ -17,7 +17,7 @@ import {hspacer} from '@xh/hoist/cmp/layout';
  *
  * Must be provided an onClick handler.
  */
-@HoistComponent()
+@HoistComponent
 export class Button extends Component {
 
     static propTypes = {

--- a/mobile/cmp/button/FeedbackButton.js
+++ b/mobile/cmp/button/FeedbackButton.js
@@ -17,7 +17,7 @@ import {Icon} from '@xh/hoist/icon';
  *
  * Can be provided an onClick handler, otherwise will use default action provided by framework.
  */
-@HoistComponent()
+@HoistComponent
 export class FeedbackButton extends Component {
 
     static propTypes = {

--- a/mobile/cmp/button/LogoutButton.js
+++ b/mobile/cmp/button/LogoutButton.js
@@ -17,7 +17,7 @@ import {toolbarButton} from '@xh/hoist/kit/onsen';
  * An onClick handler can be provided to implement additional operations on logout,
  * but should ensure it calls `XH.identityService.logoutAsync()`.
  */
-@HoistComponent()
+@HoistComponent
 export class LogoutButton extends Component {
 
     static propTypes = {

--- a/mobile/cmp/button/MenuButton.js
+++ b/mobile/cmp/button/MenuButton.js
@@ -17,7 +17,7 @@ import {toolbarButton} from '@xh/hoist/kit/onsen';
  * Must be provided either an onClick handler *or* a MenuModel. If a MenuModel is provided, this button
  * will display the menu.
  */
-@HoistComponent()
+@HoistComponent
 export class MenuButton extends Component {
 
     static propTypes = {

--- a/mobile/cmp/button/NavigatorBackButton.js
+++ b/mobile/cmp/button/NavigatorBackButton.js
@@ -10,7 +10,7 @@ import {HoistComponent, elemFactory} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
 import {toolbarButton} from '@xh/hoist/kit/onsen';
 
-@HoistComponent()
+@HoistComponent
 export class NavigatorBackButton extends Component {
 
     render() {

--- a/mobile/cmp/button/RefreshButton.js
+++ b/mobile/cmp/button/RefreshButton.js
@@ -17,7 +17,7 @@ import {toolbarButton} from '@xh/hoist/kit/onsen';
  * Must be provided either an onClick handler *or* a model. If a model is provided, this button
  * will call loadAsync() on the model class.
  */
-@HoistComponent()
+@HoistComponent
 export class RefreshButton extends Component {
 
     static propTypes = {

--- a/mobile/cmp/button/ThemeToggleButton.js
+++ b/mobile/cmp/button/ThemeToggleButton.js
@@ -13,7 +13,7 @@ import {toolbarButton} from '@xh/hoist/kit/onsen';
 /**
  * Convenience Button preconfigured for use as a trigger for light/dark theme toggling.
  */
-@HoistComponent()
+@HoistComponent
 export class ThemeToggleButton extends Component {
 
     render() {

--- a/mobile/cmp/dialog/Dialog.js
+++ b/mobile/cmp/dialog/Dialog.js
@@ -14,7 +14,7 @@ import './Dialog.scss';
 /**
  * A wrapper around Onsen's dialog, with support for standard layout + styling, titles and buttons
  */
-@HoistComponent()
+@HoistComponent
 export class Dialog extends Component {
 
     render() {

--- a/mobile/cmp/form/Label.js
+++ b/mobile/cmp/form/Label.js
@@ -14,7 +14,7 @@ import {HoistField} from '@xh/hoist/cmp/form/HoistField';
 /**
  * A simple label for a form.
  */
-@HoistComponent()
+@HoistComponent
 export class Label extends HoistField {
 
     static propTypes = {

--- a/mobile/cmp/form/SearchField.js
+++ b/mobile/cmp/form/SearchField.js
@@ -17,7 +17,7 @@ import './SearchField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class SearchField extends HoistField {
 
     static propTypes = {

--- a/mobile/cmp/form/SelectField.js
+++ b/mobile/cmp/form/SelectField.js
@@ -19,7 +19,7 @@ import './SelectField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class SelectField extends HoistField {
 
     static propTypes = {

--- a/mobile/cmp/form/TextAreaField.js
+++ b/mobile/cmp/form/TextAreaField.js
@@ -17,7 +17,7 @@ import './TextAreaField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class TextAreaField extends HoistField {
 
     static propTypes = {

--- a/mobile/cmp/form/TextField.js
+++ b/mobile/cmp/form/TextField.js
@@ -17,7 +17,7 @@ import './TextField.scss';
  *
  * @see HoistField for properties additional to those documented below.
  */
-@HoistComponent()
+@HoistComponent
 export class TextField extends HoistField {
 
     static propTypes = {

--- a/mobile/cmp/grid/Grid.js
+++ b/mobile/cmp/grid/Grid.js
@@ -13,7 +13,7 @@ import {hframe, frame, div} from '@xh/hoist/cmp/layout';
 /**
  * Grid Component
  */
-@HoistComponent()
+@HoistComponent
 export class Grid extends Component {
 
     render() {

--- a/mobile/cmp/grid/GridModel.js
+++ b/mobile/cmp/grid/GridModel.js
@@ -11,7 +11,7 @@ import {observable} from '@xh/hoist/mobx';
 /**
  * Core Model for a Grid, specifying the grid's data store and column definitions
  */
-@HoistModel()
+@HoistModel
 export class GridModel {
 
     // Immutable public properties

--- a/mobile/cmp/header/AppBar.js
+++ b/mobile/cmp/header/AppBar.js
@@ -20,7 +20,7 @@ import {navigatorBackButton, menuButton, refreshButton} from '@xh/hoist/mobile/c
  * The standard buttons which are visible will be based on user roles and application configuration,
  * or they can each be explicitly hidden.
  */
-@HoistComponent()
+@HoistComponent
 export class AppBar extends Component {
 
     static propTypes = {

--- a/mobile/cmp/mask/Mask.js
+++ b/mobile/cmp/mask/Mask.js
@@ -20,7 +20,7 @@ import './Mask.scss';
  *
  * The mask can be explicitly shown or reactively bound to a PendingTaskModel.
  */
-@HoistComponent()
+@HoistComponent
 export class Mask extends Component {
 
     static propTypes = {

--- a/mobile/cmp/menu/Menu.js
+++ b/mobile/cmp/menu/Menu.js
@@ -15,7 +15,7 @@ import {mask} from '@xh/hoist/mobile/cmp/mask';
 /**
  * Menu Component
  */
-@HoistComponent()
+@HoistComponent
 export class Menu extends Component {
 
     static propTypes = {

--- a/mobile/cmp/menu/MenuModel.js
+++ b/mobile/cmp/menu/MenuModel.js
@@ -10,7 +10,7 @@ import {isPlainObject} from 'lodash';
 
 import {MenuItemModel} from './MenuItemModel';
 
-@HoistModel()
+@HoistModel
 /** Model for a floating drop down, managing its open/close state and items. */
 export class MenuModel {
 

--- a/mobile/cmp/navigator/Navigator.js
+++ b/mobile/cmp/navigator/Navigator.js
@@ -9,7 +9,7 @@ import {Component} from 'react';
 import {HoistComponent, elemFactory} from '@xh/hoist/core';
 import {navigator as onsenNavigator} from '@xh/hoist/kit/onsen';
 
-@HoistComponent()
+@HoistComponent
 export class Navigator extends Component {
 
     render() {

--- a/mobile/cmp/navigator/NavigatorModel.js
+++ b/mobile/cmp/navigator/NavigatorModel.js
@@ -13,7 +13,7 @@ import {NavigatorPageModel} from './NavigatorPageModel';
 /**
  * Model for handling navigation between Onsen pages
  */
-@HoistModel()
+@HoistModel
 export class NavigatorModel {
     initPageModel = null;
     @observable title;

--- a/mobile/cmp/navigator/NavigatorPageModel.js
+++ b/mobile/cmp/navigator/NavigatorPageModel.js
@@ -10,7 +10,7 @@ import {uniqueId, snakeCase} from 'lodash';
 /**
  * Model for a navigator page
  */
-@HoistModel()
+@HoistModel
 export class NavigatorPageModel {
     key = null;
     pageFactory = null;

--- a/mobile/cmp/navigator/RouteNavigator.js
+++ b/mobile/cmp/navigator/RouteNavigator.js
@@ -16,7 +16,7 @@ import {XH, HoistComponent, elemFactory} from '@xh/hoist/core';
 import {navigator as onsenNavigator} from '@xh/hoist/kit/onsen';
 import {keys} from 'lodash';
 
-@HoistComponent()
+@HoistComponent
 export class RouteNavigator extends Component {
 
     _depth = -1;

--- a/mobile/cmp/page/Page.js
+++ b/mobile/cmp/page/Page.js
@@ -18,7 +18,7 @@ import {castArray} from 'lodash';
 /**
  * Wrapper around Onsen's Page component.
  */
-@HoistComponent()
+@HoistComponent
 export class Page extends Component {
 
     static propTypes = {

--- a/mobile/cmp/tab/container/TabContainer.js
+++ b/mobile/cmp/tab/container/TabContainer.js
@@ -13,7 +13,7 @@ import {tabbar} from '@xh/hoist/kit/onsen';
  * Display for a TabContainer.
  * @see TabContainerModel
  */
-@HoistComponent()
+@HoistComponent
 export class TabContainer extends Component {
 
     render() {

--- a/mobile/cmp/tab/container/TabContainerModel.js
+++ b/mobile/cmp/tab/container/TabContainerModel.js
@@ -17,7 +17,7 @@ import {TabModel} from '../pane/TabModel';
 /**
  * Model for a TabContainer, representing its tabs and the currently selected tab.
  */
-@HoistModel()
+@HoistModel
 export class TabContainerModel {
 
     /**

--- a/mobile/cmp/tab/pane/Tab.js
+++ b/mobile/cmp/tab/pane/Tab.js
@@ -15,7 +15,7 @@ import {Ref} from '@xh/hoist/utils/react';
  * Contained Pages that load data/state from the server should implement loadAsync(), but
  * generally leave the calling of that method to this component
  */
-@HoistComponent()
+@HoistComponent
 export class Tab extends Component {
 
     child = new Ref();

--- a/mobile/cmp/tab/pane/TabModel.js
+++ b/mobile/cmp/tab/pane/TabModel.js
@@ -12,7 +12,7 @@ import {max} from 'lodash';
 /**
  * Model for a Tab within a TabContainer, representing its content's active and load state.
  */
-@HoistModel()
+@HoistModel
 export class TabModel {
     id = null;
     pageFactory = null;

--- a/svc/ConfigService.js
+++ b/svc/ConfigService.js
@@ -23,7 +23,7 @@ import {cloneDeep} from 'lodash';
  * Note that this service does *not* currently attempt to reload or update configs once the client
  * application has loaded. A refresh of the application is required to load new entries.
  */
-@HoistService()
+@HoistService
 export class ConfigService {
 
     _data = {};

--- a/svc/EnvironmentService.js
+++ b/svc/EnvironmentService.js
@@ -11,7 +11,7 @@ import {SECONDS} from '@xh/hoist/utils/datetime';
 import {version as hoistReactVersion} from '@xh/hoist/package.json';
 import {defaults} from 'lodash';
 
-@HoistService()
+@HoistService
 export class EnvironmentService {
 
     _data = {};

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -21,7 +21,7 @@ import {stringify} from 'qs';
  * the main entry point 'fetch'.  These methods delegate to fetch, after setting appropriate additional
  * defaults.
  */
-@HoistService()
+@HoistService
 export class FetchService {
 
     /**

--- a/svc/IdentityService.js
+++ b/svc/IdentityService.js
@@ -13,7 +13,7 @@ import {XH, HoistService} from '@xh/hoist/core';
  * Also provides support for recognizing impersonation and distinguishing between the apparent and
  * actual underlying user.
  */
-@HoistService()
+@HoistService
 export class IdentityService {
 
     _authUser = null;

--- a/svc/IdleService.js
+++ b/svc/IdleService.js
@@ -22,7 +22,7 @@ import {debounce} from 'lodash';
  *
  * Not currently supported / enabled for mobile clients.
  */
-@HoistService()
+@HoistService
 export class IdleService {
 
     ACTIVITY_EVENTS = ['keydown', 'mousemove', 'mousedown', 'scroll'];

--- a/svc/LocalStorageService.js
+++ b/svc/LocalStorageService.js
@@ -9,7 +9,7 @@ import {XH, HoistService} from '@xh/hoist/core';
 import {throwIf} from '@xh/hoist/utils/js';
 import store from 'store2';
 
-@HoistService()
+@HoistService
 export class LocalStorageService {
     _supported = !store.isFake();
 

--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -27,7 +27,7 @@ import {throwIf} from '@xh/hoist/utils/js';
  * user values to local storage instead. This should be used for prefs that are more natural to
  * associate with a particular machine or browser (e.g. sizing or layout related options).
  */
-@HoistService()
+@HoistService
 export class PrefService {
 
     _data = {};

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -7,7 +7,7 @@
 import {XH, HoistService} from '@xh/hoist/core';
 import {stripTags} from '@xh/hoist/utils/js';
 
-@HoistService()
+@HoistService
 export class TrackService {
 
     /**

--- a/utils/async/PendingTaskModel.js
+++ b/utils/async/PendingTaskModel.js
@@ -16,7 +16,7 @@ import {isUndefined} from 'lodash';
  * the progression of asynchronous tasks.
  * @see Promise#linkTo
  */
-@HoistModel()
+@HoistModel
 export class PendingTaskModel {
 
     @observable message = null;


### PR DESCRIPTION
This feature was largely unused and added complexity to understanding and reading of these 3 decorators.  Also would yield confusing errors if users applied decorators without the '()'. 

If we need to we can restore a functional form of these in the form of a new function hanging off this function, e.g. HoistService.with({})

cr:  Anselm (pending)