### PR TITLE
Make DropDownField internalOptions observable

### DIFF
--- a/desktop/cmp/form/dropdown/BaseDropdownField.js
+++ b/desktop/cmp/form/dropdown/BaseDropdownField.js
@@ -31,8 +31,8 @@ export class BaseDropdownField extends HoistField {
         commitOnChange: false
     };
 
-    // Internal collection of available options, normalized to {label, value} form.
-    @observable internalOptions;
+    // blueprint-ready collection of available options, normalized to {label, value} form.
+    @observable.ref internalOptions = [];
 
     //---------------------------------------------------------------------------
     // Handling of null values.  Blueprint doesn't allow null for the value of a
@@ -50,9 +50,10 @@ export class BaseDropdownField extends HoistField {
     //-----------------------------------------------------------
     // Common handling of options, rendering of selected option
     //-----------------------------------------------------------
+    @action
     normalizeOptions(options) {
         options = withDefault(options, []);
-        return options.map(o => {
+        this.internalOptions = options.map(o => {
             const ret = isObject(o) ?
                 {label: o.label, value: o.value} :
                 {label: o != null ? o.toString() : '-null-', value: o};
@@ -60,11 +61,6 @@ export class BaseDropdownField extends HoistField {
             ret.value = this.toInternal(ret.value);
             return ret;
         });
-    }
-
-    @action
-    setInternalOptions(options) {
-        this.internalOptions = options;
     }
 
     getOptionRenderer() {

--- a/desktop/cmp/form/dropdown/BaseDropdownField.js
+++ b/desktop/cmp/form/dropdown/BaseDropdownField.js
@@ -7,6 +7,7 @@
 
 import {PropTypes as PT} from 'prop-types';
 import {isObject, find} from 'lodash';
+import {observable, action} from '@xh/hoist/mobx';
 import {menuItem} from '@xh/hoist/kit/blueprint';
 import {withDefault} from '@xh/hoist/utils/js';
 import {HoistField} from '@xh/hoist/cmp/form';
@@ -30,6 +31,8 @@ export class BaseDropdownField extends HoistField {
         commitOnChange: false
     };
 
+    // Internal collection of available options, normalized to {label, value} form.
+    @observable internalOptions;
 
     //---------------------------------------------------------------------------
     // Handling of null values.  Blueprint doesn't allow null for the value of a
@@ -57,6 +60,11 @@ export class BaseDropdownField extends HoistField {
             ret.value = this.toInternal(ret.value);
             return ret;
         });
+    }
+
+    @action
+    setInternalOptions(options) {
+        this.internalOptions = options;
     }
 
     getOptionRenderer() {

--- a/desktop/cmp/form/dropdown/ComboField.js
+++ b/desktop/cmp/form/dropdown/ComboField.js
@@ -39,13 +39,9 @@ export class ComboField extends BaseComboField {
 
     constructor(props) {
         super(props);
-        this.setInternalOptions(this.normalizeOptions(props.options));
+        this.addAutorun(() => this.normalizeOptions(this.props.options));
     }
-
-    componentDidMount() {
-        this.addAutorun(() => this.setInternalOptions(this.normalizeOptions(this.props.options)));
-    }
-
+    
     render() {
         const {style, width, disabled} = this.props,
             {renderValue, internalOptions} = this;

--- a/desktop/cmp/form/dropdown/ComboField.js
+++ b/desktop/cmp/form/dropdown/ComboField.js
@@ -39,11 +39,11 @@ export class ComboField extends BaseComboField {
 
     constructor(props) {
         super(props);
-        this.internalOptions = this.normalizeOptions(props.options);
+        this.setInternalOptions(this.normalizeOptions(props.options));
     }
 
     componentDidMount() {
-        this.addAutorun(() => this.internalOptions = this.normalizeOptions(this.props.options));
+        this.addAutorun(() => this.setInternalOptions(this.normalizeOptions(this.props.options)));
     }
 
     render() {

--- a/desktop/cmp/form/dropdown/QueryComboField.js
+++ b/desktop/cmp/form/dropdown/QueryComboField.js
@@ -7,7 +7,6 @@
 
 import {PropTypes as PT} from 'prop-types';
 import {elemFactory, HoistComponent} from '@xh/hoist/core';
-import {observable} from '@xh/hoist/mobx';
 import {Classes, suggest} from '@xh/hoist/kit/blueprint';
 
 import {BaseComboField} from './BaseComboField';
@@ -17,8 +16,7 @@ import {BaseComboField} from './BaseComboField';
  */
 @HoistComponent
 export class QueryComboField extends BaseComboField {
-    @observable.ref options = [];
-
+    
     static propTypes = {
         ...BaseComboField.propTypes,
 
@@ -56,17 +54,17 @@ export class QueryComboField extends BaseComboField {
 
     render() {
         const {style, width, disabled} = this.props,
-            {renderValue} = this;
+            {renderValue, internalOptions} = this;
 
         return suggest({
             className: this.getClassName(),
             popoverProps: {popoverClassName: Classes.MINIMAL},
-            $items: this.options,
+            $items: internalOptions,
             onItemSelect: this.onItemSelect,
             itemRenderer: this.getOptionRenderer(),
             inputValueRenderer: s => s,
             inputProps: {
-                value: this.getDisplayValue(renderValue, this.options, ''),
+                value: this.getDisplayValue(renderValue, internalOptions, ''),
                 onChange: this.onChange,
                 onKeyPress: this.onKeyPress,
                 onBlur: this.onBlur,
@@ -83,8 +81,8 @@ export class QueryComboField extends BaseComboField {
             {queryFn} = this.props;
 
         if (queryFn) {
-            queryFn(value).thenAction(options => {
-                this.options = this.normalizeOptions(options);
+            queryFn(value).then(options => {
+                this.normalizeOptions(options);
             });
         }
     }

--- a/desktop/cmp/form/dropdown/SelectField.js
+++ b/desktop/cmp/form/dropdown/SelectField.js
@@ -36,11 +36,11 @@ export class SelectField extends BaseDropdownField {
 
     constructor(props) {
         super(props);
-        this.internalOptions = this.normalizeOptions(props.options);
+        this.setInternalOptions(this.normalizeOptions(props.options));
     }
 
     componentDidMount() {
-        this.addAutorun(() => this.internalOptions = this.normalizeOptions(this.props.options));
+        this.addAutorun(() => this.setInternalOptions(this.normalizeOptions(this.props.options)));
     }
 
     render() {

--- a/desktop/cmp/form/dropdown/SelectField.js
+++ b/desktop/cmp/form/dropdown/SelectField.js
@@ -36,13 +36,9 @@ export class SelectField extends BaseDropdownField {
 
     constructor(props) {
         super(props);
-        this.setInternalOptions(this.normalizeOptions(props.options));
+        this.addAutorun(() => this.normalizeOptions(this.props.options));
     }
-
-    componentDidMount() {
-        this.addAutorun(() => this.setInternalOptions(this.normalizeOptions(this.props.options)));
-    }
-
+    
     render() {
         let {style, width, placeholder, disabled} = this.props,
             {renderValue, internalOptions} = this;


### PR DESCRIPTION
+ Ensures component implementations are re-rendered when props.options change and are "re-normalized" back into this internal collection.
+ Fixes #591