### PR TITLE
Grid actions column - WIP

### DIFF
--- a/desktop/cmp/actionbar/Action.js
+++ b/desktop/cmp/actionbar/Action.js
@@ -1,0 +1,41 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+export class Action {
+    /**
+     *
+     * @param {Object|Function} icon - icon to be displayed, or a function returning an icon to be
+     *      displayed.
+     * @param {string|Function} text - text to be displayed next to the icon, or a function returning
+     *      the text to be displayed.
+     * @param {ActionFn} action - called when the action button is clicked
+     * @param {*} data - data to be passed through to action when the button is clicked
+     * @param {string|Function} tooltip - tooltip to be displayed, or a function returning the tooltip
+     * @param {boolean|Function} disabled - disabled state for the action button, or a function
+     *      returning the disabled state
+     */
+    constructor({
+        icon,
+        text,
+        action,
+        data,
+        tooltip,
+        disabled
+    }) {
+        this.icon = icon;
+        this.text = text;
+        this.action = action;
+        this.data = data;
+        this.tooltip = tooltip;
+        this.disabled = disabled;
+    }
+}
+
+/**
+ * @callback ActionFn - called when the action button is clicked
+ * @param {*} data -
+ */

--- a/desktop/cmp/actionbar/ActionBar.js
+++ b/desktop/cmp/actionbar/ActionBar.js
@@ -1,0 +1,77 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {Component} from 'react';
+import {PropTypes as PT} from 'prop-types';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
+import {hbox} from '@xh/hoist/cmp/layout';
+import {button} from '@xh/hoist/desktop/cmp/button';
+import {isFunction} from 'lodash';
+
+@HoistComponent
+export class ActionBar extends Component {
+    baseClassName = 'xh-action-bar';
+
+    static propTypes = {
+        /**
+         * Actions to render in the bar. Action definitions support the following structure:
+         * {
+         *      icon,
+         *      text,
+         *      intent,
+         *      className,
+         *      action,
+         *      data,
+         *      tooltip,
+         *      disabled
+         * }
+         */
+        actions: PT.arrayOf(PT.object).isRequired
+    };
+
+    render() {
+        const {actions} = this.props;
+        return hbox({
+            className: this.getClassName(),
+            items: actions.map(action => this.renderAction(action))
+        });
+    }
+
+    renderAction(actionDef) {
+        let {icon, text, intent, className, action, data, tooltip, disabled} = actionDef;
+        icon = this.getValue(icon);
+        text = this.getValue(text);
+        intent = this.getValue(intent);
+        className = this.getValue(className);
+        tooltip = this.getValue(tooltip);
+        disabled = this.getValue(disabled);
+
+        return button({
+            icon,
+            text,
+            intent,
+            className,
+            tooltip,
+            disabled,
+            minimal: true,
+            onClick: (ev) => {
+                ev.stopPropagation();
+                action({data, props: this.props});
+            }
+        });
+    }
+
+    getValue(prop) {
+        if (isFunction(prop)) {
+            return prop();
+        }
+
+        return prop;
+    }
+}
+
+export const actionBar = elemFactory(ActionBar);

--- a/desktop/cmp/actionbar/index.js
+++ b/desktop/cmp/actionbar/index.js
@@ -1,0 +1,8 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+export * from './ActionBar';

--- a/desktop/columns/Actions.js
+++ b/desktop/columns/Actions.js
@@ -1,0 +1,18 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {actionBar} from '@xh/hoist/desktop/cmp/actionbar';
+
+export const actionsCol = {
+    colId: 'actions',
+    headerName: '',
+    chooserName: 'Actions',
+    chooserDescription: 'Row Actions',
+    align: 'center',
+    excludeFromExport: true,
+    elementRenderer: actionBar
+};

--- a/desktop/columns/index.js
+++ b/desktop/columns/index.js
@@ -1,0 +1,8 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+export * from './Actions';


### PR DESCRIPTION
Initial pass at support actions grid columns. #549 

Extended the Column API to accept `rendererParams` to be passed through to the `renderer` or `elementRenderer` (the mechanism for passing the action definitions through to the ActionBar component)

ActionBar component which accepts a collection of action definitions, and simply renders them in a row as minimal buttons. Action definition properties can be a value or a function which returns a value (where it makes sense).

Also made some changes for #575 as part of this

@lbwexler did a quick review with @amcclain of this approach, wanted your feedback on whether this seems like a sounds approach or if something more object-oriented and explicit (ActionColumn, pass actions to the GridModel, etc.) would be preferable.

See https://github.com/exhi/toolbox/commit/035f035a044385770d2e1b9467fbe7c3b7bc94d3 for an action column example.