### PR TITLE
MultiSelect Placeholder Bug

### DIFF
--- a/desktop/cmp/form/dropdown/MultiSelectField.js
+++ b/desktop/cmp/form/dropdown/MultiSelectField.js
@@ -67,6 +67,7 @@ export class MultiSelectField extends BaseDropdownField {
                 tagProps: {minimal: true},
                 className: this.getClassName(),
                 placeholder,
+                inputProps: {placeholder: ''},
                 onRemove: this.onRemoveTag
             },
             selectedItems: this.externalValue || [],

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,9 +210,9 @@
     eslint "~4.19.1"
     eslint-plugin-react "~7.7.0"
 
-"@xh/hoist-dev-utils@~2.2.1":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@xh/hoist-dev-utils/-/hoist-dev-utils-2.2.1.tgz#40bfed1be1fa0fd9d36fc30c6c0730836277348c"
+"@xh/hoist-dev-utils@~2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@xh/hoist-dev-utils/-/hoist-dev-utils-2.2.2.tgz#5d864288f4609d9c363a4be85636b950bc55d952"
   dependencies:
     "@xh/eslint-config" "~0.2.1"
     autoprefixer "~8.5.0"


### PR DESCRIPTION
Still not sure why the 'Search...' placeholder displays after selecting an option. This is a workaround which explicitly sets inputProps.placeholder to an empty string. Per the documentation below I don't think we should have to do this.

<img width="704" alt="screen shot 2018-09-13 at 5 17 01 pm" src="https://user-images.githubusercontent.com/33368494/45516499-461c8480-b779-11e8-96e3-7bd823d74618.png">
