### PR TITLE
Fix issues with changing groupBy after initial call

### DIFF
--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -223,7 +223,7 @@ export class GridModel {
         if (field && !groupCol) return;
 
         cols.forEach(it => {
-            if (it.rowGroup) {
+            if (it.agOptions && it.agOptions.rowGroup) {
                 it.agOptions.rowGroup = false;
                 it.hide = false;
             }


### PR DESCRIPTION
#644

Didn't dig too deep, but probably broke with the column definition refactoring, just needed to look for the `rowGroup` property in the correct place.

Added example of changing the groupBy field to toolbox in https://github.com/exhi/toolbox/commit/a3fa4485babde8af642db083e398f414c6c43005