### PR TITLE
Add GridModel.expandAll() and collapseAll() w/context menu tokens

### DIFF
--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -30,8 +30,7 @@ export class StoreContextMenu {
      *
      *      Hoist tokens, all of which require a GridModel:
      *          `colChooser` - display column chooser for a grid.
-     *          `expandAll` - expand all nodes on a row-grouped or tree grid.
-     *          `collapseAll` - collapse all nodes on a row-grouped or tree grid.
+     *          `expandCollapse` - options to expand/collapse all parent rows on grouped/tree grid.
      *          `export` - export grid data to excel via Hoist's server-side export capabilities.
      *          `exportExcel` - same as above.
      *          `exportCsv` - export grid data to CSV via Hoist's server-side export capabilities.

--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -30,7 +30,7 @@ export class StoreContextMenu {
      *
      *      Hoist tokens, all of which require a GridModel:
      *          `colChooser` - display column chooser for a grid.
-     *          `expandCollapse` - options to expand/collapse all parent rows on grouped/tree grid.
+     *          `expandCollapseAll` - expand/collapse all parent rows on grouped or tree grid.
      *          `export` - export grid data to excel via Hoist's server-side export capabilities.
      *          `exportExcel` - same as above.
      *          `exportCsv` - export grid data to CSV via Hoist's server-side export capabilities.
@@ -80,7 +80,7 @@ export class StoreContextMenu {
                         gridModel.export({type: 'csv'});
                     }
                 });
-            case 'expandCollapse':
+            case 'expandCollapseAll':
                 return [
                     new RecordAction({
                         text: 'Expand All',

--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {isString} from 'lodash';
+import {isString, flatten} from 'lodash';
 import {RecordAction} from '@xh/hoist/data';
 import {Icon} from '@xh/hoist/icon';
 
@@ -30,6 +30,8 @@ export class StoreContextMenu {
      *
      *      Hoist tokens, all of which require a GridModel:
      *          `colChooser` - display column chooser for a grid.
+     *          `expandAll` - expand all nodes on a row-grouped or tree grid.
+     *          `collapseAll` - collapse all nodes on a row-grouped or tree grid.
      *          `export` - export grid data to excel via Hoist's server-side export capabilities.
      *          `exportExcel` - same as above.
      *          `exportCsv` - export grid data to CSV via Hoist's server-side export capabilities.
@@ -40,9 +42,9 @@ export class StoreContextMenu {
      */
     constructor({items, gridModel}) {
         this.gridModel = gridModel;
-        this.items = items.map(it => {
+        this.items = flatten(items.map(it => {
             return isString(it) ? this.parseToken(it) : new RecordAction(it);
-        });
+        }));
     }
 
     parseToken(token) {
@@ -79,6 +81,21 @@ export class StoreContextMenu {
                         gridModel.export({type: 'csv'});
                     }
                 });
+            case 'expandCollapse':
+                return [
+                    new RecordAction({
+                        text: 'Expand All',
+                        icon: Icon.chevronDown(),
+                        hidden: !gridModel || !(gridModel.treeMode || gridModel.groupBy),
+                        actionFn: () => gridModel.expandAll()
+                    }),
+                    new RecordAction({
+                        text: 'Collapse All',
+                        icon: Icon.chevronRight(),
+                        hidden: !gridModel || !(gridModel.treeMode || gridModel.groupBy),
+                        actionFn: () => gridModel.collapseAll()
+                    })
+                ];
             case 'exportLocal':
                 return 'export';
             default:

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -86,7 +86,7 @@ export class GridModel {
         'copy',
         'copyWithHeaders',
         '-',
-        'expandCollapse',
+        'expandCollapseAll',
         '-',
         'exportExcel',
         'exportCsv',

--- a/desktop/cmp/grid/GridModel.js
+++ b/desktop/cmp/grid/GridModel.js
@@ -86,6 +86,8 @@ export class GridModel {
         'copy',
         'copyWithHeaders',
         '-',
+        'expandCollapse',
+        '-',
         'exportExcel',
         'exportCsv',
         '-',
@@ -249,7 +251,18 @@ export class GridModel {
             groupCol.hide = true;
         }
 
+        this.groupBy = colId;
         this.columns = [...cols];
+    }
+
+    /** Expand all parent rows in grouped or tree grid. (Note, this is recursive for trees!) */
+    expandAll() {
+        this.agApi.expandAll();
+    }
+
+    /** Collapse all parent rows in grouped or tree grid. */
+    collapseAll() {
+        this.agApi.collapseAll();
     }
 
     /**
@@ -315,14 +328,17 @@ export class GridModel {
     }
 
     /**
-     * This method will update the current column definition with respect to sort order, width and visibility of columns.
-     * Used by both Hoist's grid state plugin (GridStateModel) and in response to state changes as detected by ag-grid.
+     * This method will update the current column definition with respect to sort order, width and
+     * visibility of columns. Used by both Hoist's grid state plugin (GridStateModel) and in
+     * response to state changes as detected by ag-grid.
      *
-     * note: Sort order is driven by the individual columns in the state param. This means that if a column has been
-     * redefined to a new column group that entire group may be moved by this state param.
+     * Note: Column ordering is determined by the individual (leaf-level) columns in state.
+     * This means that if a column has been redefined to a new column group, that entire group may
+     * be moved to a new index.
      *
      * @param {Object[]} colState - configs representing the order, width and visibility of columns.
-     *       In the case of a grid with grouped columns, the columns here represent only the leaves or bottom level columns.
+     *       In the case of a grid with grouped columns, the columns here represent only the leaves
+     *       or bottom level columns.
      */
     @action
     applyColumnChanges(colState) {

--- a/desktop/cmp/grid/ag-grid/styles.scss
+++ b/desktop/cmp/grid/ag-grid/styles.scss
@@ -24,6 +24,10 @@
     .ag-menu-option.ag-menu-option-active {
       background-color: var(--xh-bg-highlight);
     }
+
+    .ag-menu-option-icon {
+      text-align: center;
+    }
   }
 
   .ag-root {

--- a/desktop/cmp/grid/ag-grid/styles.scss
+++ b/desktop/cmp/grid/ag-grid/styles.scss
@@ -5,30 +5,9 @@
   height: auto !important;
 }
 
-.ag-menu {
-  z-index: 9999 !important; // always show context menus above other content, e.g. dialog
-}
-
 .xh-grid {
   font-family: var(--xh-grid-font-family);
   font-size: var(--xh-grid-font-size-px);
-
-  .ag-menu {
-    font-family: var(--xh-font-family);
-    background-color: var(--xh-bg-alt);
-
-    // Matching no border + box-shadow of Blueprint context menu popover
-    border: none;
-    box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
-
-    .ag-menu-option.ag-menu-option-active {
-      background-color: var(--xh-bg-highlight);
-    }
-
-    .ag-menu-option-icon {
-      text-align: center;
-    }
-  }
 
   .ag-root {
     border: none;
@@ -172,4 +151,24 @@
 
 .xh-column-header-align-center .xh-grid-header {
   text-align: center;
+}
+
+// ag-Grid context menu customizations
+.ag-theme-balham .ag-menu, .ag-theme-balham-dark .ag-menu {
+  z-index: 9999 !important; // always show context menus above other content, e.g. dialog
+
+  font-family: var(--xh-font-family);
+  background-color: var(--xh-bg-alt);
+
+  // Matching no border + box-shadow of Blueprint context menu popover
+  border: none;
+  box-shadow: 0 0 0 1px rgba(16, 22, 26, 0.2), 0 2px 4px rgba(16, 22, 26, 0.4), 0 8px 24px rgba(16, 22, 26, 0.4);
+
+  .ag-menu-option.ag-menu-option-active {
+    background-color: var(--xh-bg-highlight);
+  }
+
+  .ag-menu-option-icon {
+    text-align: center;
+  }
 }


### PR DESCRIPTION
+ Note fix to actually set the observable groupBy within `GridModel.setGroupBy()` - even if we don't want this overall change we should be sure to apply that!
+ Context menu token provided to add both actions at once - I didn't see a use-case for only adding one...
+ Added to default context menu, although items will hide if grid is not tree/grouped.
+ Warning in comment on expandAll that this is recursive. Further work could absolutely be smarter about expanding only a single level, or optionally expanding only the selected node.
+ Center align grid context menu icons - looked much better with > icon.
+ Fixes #640 