### PR TITLE
Implementation of fetchservice cancellable by requestKey

### DIFF
--- a/core/ExceptionHandler.js
+++ b/core/ExceptionHandler.js
@@ -129,6 +129,10 @@ export class ExceptionHandler {
         const ret = Object.assign({}, options),
             isAutoRefresh = exception.fetchOptions && exception.fetchOptions.isAutoRefresh;
 
+        if (exception.name == 'AbortError') {
+            ret.showAlert = ret.logOnServer = false;
+        }
+
         ret.showAsError = ret.showAsError != null ? ret.showAsError : true;
         ret.logOnServer = ret.logOnServer != null ? ret.logOnServer : ret.showAsError;
         ret.showAlert = ret.showAlert != null ? ret.showAlert : !isAutoRefresh;

--- a/core/ExceptionHandler.js
+++ b/core/ExceptionHandler.js
@@ -7,7 +7,7 @@
 import {Exception} from '@xh/hoist/exception';
 import {XH} from './XH';
 import {stringifyErrorSafely} from '@xh/hoist/exception';
-import {stripTags} from '@xh/hoist/utils/js';
+import {stripTags, withDefault} from '@xh/hoist/utils/js';
 
 /**
  * Provides Centralized Exception Handling for Hoist Application.
@@ -122,21 +122,24 @@ export class ExceptionHandler {
     logException(exception, options) {
         return (options.showAsError) ?
             console.error(options.message, exception) :
-            console.log(options.message, exception);
+            console.log(options.message);
     }
 
     parseOptions(exception, options) {
         const ret = Object.assign({}, options),
             isAutoRefresh = exception.fetchOptions && exception.fetchOptions.isAutoRefresh;
 
-        if (exception.name == 'AbortError') {
-            ret.showAlert = ret.logOnServer = false;
-        }
-
-        ret.showAsError = ret.showAsError != null ? ret.showAsError : true;
-        ret.logOnServer = ret.logOnServer != null ? ret.logOnServer : ret.showAsError;
-        ret.showAlert = ret.showAlert != null ? ret.showAlert : !isAutoRefresh;
         ret.requireReload = !!ret.requireReload;
+
+        if (exception.name == 'Fetch Aborted') {
+            ret.showAsError = withDefault(ret.showAsError, false);
+            ret.logOnServer = withDefault(ret.logOnServer, false);
+            ret.showAlert = withDefault(ret.showAlert, false);
+        } else {
+            ret.showAsError = withDefault(ret.showAsError, true);
+            ret.logOnServer = withDefault(ret.logOnServer, ret.showAsError);
+            ret.showAlert = withDefault(ret.showAlert, !isAutoRefresh);
+        }
 
         ret.title = ret.title || (ret.showAsError ? 'Error' : 'Message');
         ret.message = ret.message || exception.message || exception.name || 'An unknown error occurred.';

--- a/exception/Exception.js
+++ b/exception/Exception.js
@@ -71,6 +71,14 @@ export class Exception {
         return this.createInternal(defaults, {});
     }
 
+    static fetchCancelled(fetchOptions, response) {
+        return this.createInternal({
+            name: response.name,
+            message: `Fetch request cancelled | requestKey: "${fetchOptions.requestKey}" | url: "${fetchOptions.url}"`,
+            fetchOptions
+        });
+    }
+
     /**
      * Create an Error for when the server called by fetch does not respond
      * @param {Object} fetchOptions - original options the app passed to FetchService.fetch

--- a/exception/Exception.js
+++ b/exception/Exception.js
@@ -71,10 +71,16 @@ export class Exception {
         return this.createInternal(defaults, {});
     }
 
-    static fetchCancelled(fetchOptions, response) {
+    /**
+     * Create an Error for when fetch calls are aborted
+     * @param {Object} fetchOptions - original options the app passed to FetchService.fetch
+     * @param {Response} response - resolved value from native fetch
+     * @returns {Error}
+     */
+    static fetchAborted(fetchOptions, response) {
         return this.createInternal({
-            name: response.name,
-            message: `Fetch request cancelled | requestKey: "${fetchOptions.requestKey}" | url: "${fetchOptions.url}"`,
+            name: 'Fetch Aborted',
+            message: `Fetch request aborted, url: "${fetchOptions.url}"`,
             fetchOptions
         });
     }

--- a/svc/FetchService.js
+++ b/svc/FetchService.js
@@ -45,11 +45,12 @@ export class FetchService {
      * @param {Object} [opts.qsOpts] - Object of options to pass to the param converter library, qs.
      *      The default qsOpts are: {arrayFormat: 'repeat', allowDots: true}.
      *      @see {@link https://www.npmjs.com/package/qs}
+     * @param {string} [opts.requestKey] - Key to the abort object to call when cancelling an in flight request.
      *
      * @returns {Promise<Response>} - Promise which resolves to a Fetch Response.
      */
     async fetch(opts) {
-        let {params, method, contentType, url} = opts;
+        let {params, method, contentType, url, requestKey} = opts;
 
         // 1) Compute / install defaults
         if (!method) {
@@ -93,6 +94,14 @@ export class FetchService {
             }
         }
 
+        // 4) Cancel prior request, adn add new AbortController if requestKey used
+        if (requestKey) {
+            this.abort(requestKey);
+            const ctlr = new AbortController();
+            fetchOpts.signal = ctlr.signal;
+            this.abortControllers[requestKey] = ctlr;
+        }
+
         delete fetchOpts.contentType;
         delete fetchOpts.url;
 
@@ -100,7 +109,12 @@ export class FetchService {
         try {
             ret = await fetch(url, fetchOpts);
         } catch (e) {
+            if (e.name == 'AbortError') throw Exception.fetchCancelled(opts, e);
             throw Exception.serverUnavailable(opts, e);
+        }
+
+        if (opts.requestKey) {
+            delete this.abortControllers[opts.requestKey];
         }
 
         if (!ret.ok) {
@@ -158,9 +172,19 @@ export class FetchService {
         return this.sendJson(opts);
     }
 
+    abort(key) {
+        const ctrl = this.abortControllers[key];
+        if (!ctrl) return;
+
+        delete this.abortControllers[key];
+        ctrl.abort();
+    }
+
     //-----------------------
     // Implementation
     //-----------------------
+    abortControllers = {};
+
     async sendJson(opts) {
         opts = {
             ...opts,


### PR DESCRIPTION
This resolves issue: https://github.com/exhi/hoist-react/issues/698

There is a corresponding toolbox branch (fetchservice_cancel) which does not need to be merged in, but can be used to test this implementation by cancelling News refreshes.