### PR TITLE
RecordAction sub-menu fix

### DIFF
--- a/data/RecordAction.js
+++ b/data/RecordAction.js
@@ -127,6 +127,7 @@ export class RecordAction {
      * @param {*} [p...rest] - additional data provided by the context where this action presides
      */
     call({record, selectedRecords, gridModel, column, ...rest}) {
+        if (!this.actionFn) return;
         this.actionFn({action: this, record, selectedRecords, gridModel, column, ...rest});
     }
 

--- a/desktop/cmp/contextmenu/StoreContextMenu.js
+++ b/desktop/cmp/contextmenu/StoreContextMenu.js
@@ -5,10 +5,9 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {isEmpty, isString, flatten, isPlainObject} from 'lodash';
+import {isEmpty, isString, flatten} from 'lodash';
 import {RecordAction} from '@xh/hoist/data';
 import {Icon} from '@xh/hoist/icon';
-import {throwIf} from '@xh/hoist/utils/js';
 
 /**
  * Model for ContextMenus interacting with data provided by Hoist data stores, typically via a Grid.
@@ -23,7 +22,7 @@ export class StoreContextMenu {
 
     /**
      * @param {Object} c - StoreContextMenu configuration.
-     * @param {Object[]} c.items - RecordAction configs or token strings to create.
+     * @param {Object[]} c.items - RecordActions, configs or token strings to create.
      *
      *      If a String, value can be '-' for a separator, a Hoist token (below),
      *      or a token supported by ag-Grid for its native menu items.
@@ -48,9 +47,7 @@ export class StoreContextMenu {
     buildRecordAction(item) {
         if (isString(item)) return this.parseToken(item);
 
-        throwIf(!isPlainObject(item), 'Only strings and RecordAction config objects are supported as context menu items!');
-
-        const ret = new RecordAction(item);
+        const ret = (item instanceof RecordAction) ? item : new RecordAction(item);
         if (!isEmpty(ret.items)) {
             ret.items = ret.items.map(it => this.buildRecordAction(it));
         }

--- a/desktop/cmp/grid/Grid.js
+++ b/desktop/cmp/grid/Grid.js
@@ -11,6 +11,7 @@ import {observable, runInAction} from '@xh/hoist/mobx';
 import {elemFactory, HoistComponent, LayoutSupport, XH} from '@xh/hoist/core';
 import {box, fragment} from '@xh/hoist/cmp/layout';
 import {convertIconToSvg, Icon} from '@xh/hoist/icon';
+import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
 import './ag-grid';
 import {agGridReact, navigateSelection, ColumnHeader} from './ag-grid';
 import {colChooser} from './ColChooser';
@@ -217,9 +218,10 @@ export class Grid extends Component {
             const displaySpec = action.getDisplaySpec(params);
             if (displaySpec.hidden) return;
 
-            let subMenu;
+            let childItems;
             if (!isEmpty(displaySpec.items)) {
-                subMenu = this.buildMenuItems(displaySpec.items, record, selectedRecords);
+                const menu = new StoreContextMenu({items: displaySpec.items, gridModel: this.gridModel});
+                childItems = this.buildMenuItems(menu.items, record, selectedRecords);
             }
 
             let icon = displaySpec.icon;
@@ -230,7 +232,7 @@ export class Grid extends Component {
             items.push({
                 name: displaySpec.text,
                 icon,
-                subMenu,
+                subMenu: childItems,
                 tooltip: displaySpec.tooltip,
                 disabled: displaySpec.disabled,
                 action: () => action.call(params)


### PR DESCRIPTION
Encountered a couple issues while using the new features in a client-app. The main change here is adding support for dynamic sub menus returned from the `displayFn` callback. Previously we were just taking them and assuming that they are RecordActions (which they would have been if they were statically defined in the RecordAction config).

