### PR TITLE
Add ag-Grid valueGetters to treeCol

### DIFF
--- a/columns/Column.js
+++ b/columns/Column.js
@@ -197,6 +197,8 @@ export class Column {
                 suppressDoubleClickExpand: true,
                 innerRenderer: (v) => v.data[this.field]
             };
+            ret.valueGetter = (v) => v.data[this.field];
+            ret.filterValueGetter = (v) => v.data[this.field];
         }
 
         if (this.tooltip) {


### PR DESCRIPTION
+ For review - not sure what effect of valueGetter is - filterValueGetter does extract the intended values for the ag-grid filter menu if enabled.
+ Sorting still not right - did not look yet
+ Noticed that for treeCol we assume renderer is just extracting field from val - I think that's fine but is it worth throwing an exception or warning if someone tries to use a renderer on a treecol?