### PR TITLE
Fixes to value handling for treeColumn

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -162,6 +162,7 @@ export class Grid extends Component {
             onGridSizeChanged: this.onGridSizeChanged,
             onDragStopped: this.onDragStopped,
             onColumnResized: this.onColumnResized,
+            processCellForClipboard: this.processCellForClipboard,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true
         };
@@ -435,6 +436,12 @@ export class Grid extends Component {
 
     writeFilterState(api, filterState) {
         api.setFilterModel(filterState);
+    }
+
+    // Underlying value for treeColumns is actually the record ID due to getDataPath() impl.
+    // Special handling here, similar to that in Column class, to extract the desired value.
+    processCellForClipboard({value, node, column}) {
+        return column.isTreeColumn ? node.data[column.field] : value;
     }
 
 }

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -37,7 +37,7 @@ import {ExportManager} from './impl/ExportManager';
  * This model also supports nested tree data. To show a tree:
  *   1) Bind this model to a store with hierarchical records.
  *   2) Set `treeMode: true` on this model.
- *   3) Include a a single column with `isTreeColumn: true`. This column will provide expand /
+ *   3) Include a single column with `isTreeColumn: true`. This column will provide expand /
  *      collapse controls and indent child columns in addition to displaying its own data.
  *
  */
@@ -277,7 +277,6 @@ export class GridModel {
         const {agApi} = this;
         if (agApi) {
             agApi.expandAll();
-
         }
     }
 
@@ -329,8 +328,10 @@ export class GridModel {
     /** @param {Object[]} colConfigs - {@link Column} or {@link ColumnGroup} configs. */
     @action
     setColumns(colConfigs) {
-        throwIf(colConfigs.some(c => !isPlainObject(c)),
-            'setColumns only accepts plain objects for Column or ColumnGroup configs!');
+        throwIf(
+            colConfigs.some(c => !isPlainObject(c)),
+            'GridModel only accepts plain objects for Column or ColumnGroup configs'
+        );
 
         const columns = colConfigs.map(c => this.buildColumn(c));
 
@@ -467,6 +468,12 @@ export class GridModel {
 
         const groupColsHaveDupes = groupIds.length != uniq(groupIds).length;
         throwIf(groupColsHaveDupes, 'All groupIds in column collection must be unique.');
+
+        const treeCols = cols.filter(it => it.isTreeColumn);
+        warnIf(
+            this.treeMode && treeCols.length != 1,
+            'Grids in treeMode should include exactly one column with isTreeColumn:true.'
+        );
 
         warnIf(
             !cols.some(c => c.flex),

--- a/data/Field.js
+++ b/data/Field.js
@@ -5,6 +5,8 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
+import {Record} from '@xh/hoist/data/Record';
+import {throwIf} from '@xh/hoist/utils/js';
 import {startCase} from 'lodash';
 
 /**
@@ -34,6 +36,12 @@ export class Field {
         nullable = true,
         defaultValue = null
     }) {
+
+        throwIf(
+            Record.RESERVED_FIELD_NAMES.includes(name),
+            `Field name "${name}" cannot be used. It is reserved as a top-level property of the Record class.`
+        );
+
         this.name = name;
         this.type = type;
         this.label = label;

--- a/data/Record.js
+++ b/data/Record.js
@@ -15,8 +15,12 @@ import {clone} from 'lodash';
  */
 export class Record {
 
-    /** @member {string} - unique id. */
+    static RESERVED_FIELD_NAMES = ['raw', 'fields', 'children', 'parent']
+
+    /** @member {string} - unique ID. */
     id
+    /** @member {Object} - unconverted source data. */
+    raw
     /** @member {Fields[]} - fields for this record. */
     fields
     /** @member {Record[]} - Children of this record. */


### PR DESCRIPTION
+ Our implementation of getDataPath() -> Record.xhTreePath results in treeColumn cells having the record ID as their underlying value via the node's groupData property. This is prioritized by default over the field value for filtering, sorting, and copying.
+ Fixes #679 