### PR TITLE
Parameterized decorator check

### DIFF
--- a/field/FieldSupport.js
+++ b/field/FieldSupport.js
@@ -12,7 +12,7 @@ import {startCase, partition, isFunction, isEmpty, isString, forOwn} from 'lodas
 import {Field} from './Field';
 import {FieldsModel} from './impl/FieldsModel';
 import {bindable} from '@xh/hoist/mobx';
-import {throwIf} from '@xh/hoist/utils/js';
+import {throwIf, ensureParameterizedDecoratorPreCalled} from '@xh/hoist/utils/js';
 import {ValidationState} from './validation/ValidationState';
 
 
@@ -170,8 +170,10 @@ export function FieldSupport(C) {
  * added to this field.
  */
 export function field(...params) {
-    return (target, property, descriptor) => {
 
+    ensureParameterizedDecoratorPreCalled('field', ...params);
+
+    return (target, property, descriptor) => {
         // 0) Prepare static property on class itself to host field configs.
         if (!target._xhFieldConfigs) {
             Object.defineProperty(target, '_xhFieldConfigs', {value: {}});

--- a/utils/js/Decorators.js
+++ b/utils/js/Decorators.js
@@ -10,20 +10,20 @@ import {isObject} from 'lodash';
  * Log an error if a parameterized decorator is applied without being called first.
  *
  * Call this when defining a 'parameterized' decorator that needs to be called as a function.
- * This will throw if the decorator is ever applied to a property without calling it first.
+ * This will throw if the decorator is ever applied to a property without calling it first -
+ * an easy-to-make mistake given that many core decorators are *not* parameterized. See the
+ * implementation of `field` decorator for an example.
  *
- *  @param {string} name - the name of the decorator being defined.
+ *  @param {string} decoratorName - the name of the decorator being defined.
  *  @param {...*} params - the arguments passed to the invocation of the parameterized decorator.
- *
- * See implementation of `field` decorator for an example.
  */
 export function ensureParameterizedDecoratorPreCalled(decoratorName, ...params) {
 
     if (params.length === 3 && isObject(params[2]) && ('configurable' in params[2] || 'enumerable' in params[2])) {
         throw new Error(
-            `It looks like you are using the '${decoratorName}' decorator without calling it as function.` +
-            `Ensure it is called as @${decoratorName}(), even if you are not providing it with any arguments.  ` +
-            `Target: ${params[0].constructor.name}. Property: ${params[1]}`
+            `It looks like you are using the '${decoratorName}' decorator on ` +
+            `${params[0].constructor.name}.${params[1]} without calling it as a function. ` +
+            `Ensure it is called as @${decoratorName}(), even if you are not providing it with any arguments.`
         );
     }
 }

--- a/utils/js/Decorators.js
+++ b/utils/js/Decorators.js
@@ -1,0 +1,29 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+import {isObject} from 'lodash';
+
+/**
+ * Log an error if a parameterized decorator is applied without being called first.
+ *
+ * Call this when defining a 'parameterized' decorator that needs to be called as a function.
+ * This will throw if the decorator is ever applied to a property without calling it first.
+ *
+ *  @args {String} name, the name of the decorator being defined.
+ *  @args {...*} params, the arguments passed to the invocation of the parameterized decorator.
+ *
+ * See implementation of `field` decorator for an example.
+ */
+export function ensureParameterizedDecoratorPreCalled(decoratorName, ...params) {
+
+    if (params.length === 3 && isObject(params[2]) && ('configurable' in params[2] || 'enumerable' in params[2])) {
+        throw new Error(
+            `It looks like you are using the '${decoratorName}' decorator without calling it as function.` +
+            `Ensure it is called as @${decoratorName}(), even if you are not providing it with any arguments.  ` +
+            `Target: ${params[0].constructor.name}. Property: ${params[1]}`
+        );
+    }
+}

--- a/utils/js/Decorators.js
+++ b/utils/js/Decorators.js
@@ -12,8 +12,8 @@ import {isObject} from 'lodash';
  * Call this when defining a 'parameterized' decorator that needs to be called as a function.
  * This will throw if the decorator is ever applied to a property without calling it first.
  *
- *  @args {String} name, the name of the decorator being defined.
- *  @args {...*} params, the arguments passed to the invocation of the parameterized decorator.
+ *  @param {string} name - the name of the decorator being defined.
+ *  @param {...*} params - the arguments passed to the invocation of the parameterized decorator.
  *
  * See implementation of `field` decorator for an example.
  */

--- a/utils/js/index.js
+++ b/utils/js/index.js
@@ -7,3 +7,4 @@
 export * from './ClassUtils';
 export * from './HtmlUtils';
 export * from './LangUtils';
+export * from './Decorators';


### PR DESCRIPTION
I went back and forth on whether to throw, or just console.error, but ultimately decided to throw.

If you were to just spell the decorator wrong, (e.g. 'feild') it throws at runtime in the browser, so I thought it made sense to do the same here.