### PR TITLE
Clone the pref value on set for the internal cache and event params (Fixes #765)

### DIFF
--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -94,11 +94,11 @@ export class PrefService {
         if (isEqual(oldValue, value)) return;
 
         // Change local value and fire.
-        this._data[key].value = value;
-        this.fireEvent('prefChange', {key, value, oldValue});
+        this._data[key].value = cloneDeep(value);
+        this.fireEvent('prefChange', {key, value: cloneDeep(value), oldValue});
 
         // Schedule serialization to storage
-        this._updates[key] = value;
+        this._updates[key] = this._data[key].value;
         this.pushPendingBuffered();
     }
 
@@ -230,7 +230,6 @@ export class PrefService {
 
     validateBeforeSet(key, value) {
         const pref = this._data[key];
-
 
         throwIf(!pref, `Cannot set preference ${key}: not found`);
 


### PR DESCRIPTION
#765 

Make sure that we don't hold a reference to the value passed to PrefService.set()

See https://github.com/exhi/toolbox/commit/4b8f805e5a86ff0c5f9489bbe5ab06656fcf9d3a for a demo of the issue if curious (not intended to be merged, will delete after this is pr merged)