### PR TITLE
Deep Freeze Shared enumerable data from various services

### DIFF
--- a/svc/ConfigService.js
+++ b/svc/ConfigService.js
@@ -5,8 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 import {XH, HoistService} from '@xh/hoist/core';
-import {throwIf} from '@xh/hoist/utils/js';
-import {cloneDeep} from 'lodash';
+import {throwIf, deepFreeze} from '@xh/hoist/utils/js';
 
 /**
  * Service to read soft-configuration values.
@@ -30,6 +29,7 @@ export class ConfigService {
 
     async initAsync() {
         this._data = await XH.fetchJson({url: 'xh/getConfig'});
+        deepFreeze(this._data);
     }
 
     /**
@@ -45,7 +45,7 @@ export class ConfigService {
         const data = this._data;
 
         if (data.hasOwnProperty(key)) {
-            return cloneDeep(data[key]);
+            return data[key];
         }
 
         throwIf(defaultValue === undefined, `Config key not found: '${key}'`);

--- a/svc/EnvironmentService.js
+++ b/svc/EnvironmentService.js
@@ -10,6 +10,7 @@ import {Timer} from '@xh/hoist/utils/async';
 import {SECONDS} from '@xh/hoist/utils/datetime';
 import {version as hoistReactVersion} from '@xh/hoist/package.json';
 import {defaults} from 'lodash';
+import {deepFreeze} from '@xh/hoist/utils/js';
 
 @HoistService
 export class EnvironmentService {
@@ -29,6 +30,8 @@ export class EnvironmentService {
             hoistReactVersion: hoistReactVersion,
             reactVersion: React.version
         }, serverEnv);
+
+        deepFreeze(this._data);
 
         this.addReaction({
             when: () => XH.appIsRunning,

--- a/svc/IdentityService.js
+++ b/svc/IdentityService.js
@@ -5,6 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 import {XH, HoistService} from '@xh/hoist/core';
+import {deepFreeze} from '@xh/hoist/utils/js';
 
 /**
  * Provides basic information related to the authenticated user, including application roles.
@@ -22,10 +23,10 @@ export class IdentityService {
     async initAsync() {
         const data = await XH.fetchJson({url: 'xh/getIdentity'});
         if (data.user) {
-            this._apparentUser = this._authUser = this.enhanceUser(data.user, data.roles);
+            this._apparentUser = this._authUser = this.createUser(data.user, data.roles);
         } else {
-            this._apparentUser = this.enhanceUser(data.apparentUser, data.apparentUserRoles);
-            this._authUser = this.enhanceUser(data.authUser, data.authUserRoles);
+            this._apparentUser = this.createUser(data.apparentUser, data.apparentUserRoles);
+            this._authUser = this.createUser(data.authUser, data.authUserRoles);
         }
     }
 
@@ -89,13 +90,13 @@ export class IdentityService {
     //------------------------
     // Implementation
     //------------------------
-    enhanceUser(user, roles) {
+    createUser(user, roles) {
         if (!user) return null;
         user.roles = roles;
         user.hasRole = (role) => user.roles.includes(role);
         user.isHoistAdmin = user.hasRole('HOIST_ADMIN');
         user.hasGate = (gate) => this.hasGate(gate, user);
-        return user;
+        return deepFreeze(user);
     }
 
     hasGate(gate, user) {

--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -93,8 +93,8 @@ export class PrefService {
         const oldValue = this.get(key);
         if (isEqual(oldValue, value)) return;
 
-        // Change local value and fire.
-        deepFreeze(value);
+        // Change local value to sanitized copy and fire.
+        deepFreeze(cloneDeep(value));
         this._data[key].value = value;
         this.fireEvent('prefChange', {key, value, oldValue});
 

--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -4,10 +4,10 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-import {cloneDeep, debounce, isNil, isEqual, isEmpty, pickBy, map} from 'lodash';
+import {debounce, isNil, isEqual, isEmpty, pickBy, map, cloneDeep, forEach} from 'lodash';
 import {XH, HoistService} from '@xh/hoist/core';
 import {SECONDS} from '@xh/hoist/utils/datetime';
-import {throwIf} from '@xh/hoist/utils/js';
+import {throwIf, deepFreeze} from '@xh/hoist/utils/js';
 
 /**
  * Service to read and set user-specific preference values.
@@ -71,7 +71,7 @@ export class PrefService {
         }
 
         throwIf(ret === undefined, `Preference key not found: '${key}'`);
-        return cloneDeep(ret);
+        return ret;
     }
 
     /**
@@ -94,6 +94,7 @@ export class PrefService {
         if (isEqual(oldValue, value)) return;
 
         // Change local value and fire.
+        deepFreeze(value);
         this._data[key].value = value;
         this.fireEvent('prefChange', {key, value, oldValue});
 
@@ -178,10 +179,15 @@ export class PrefService {
     //  Implementation
     //-------------------
     async loadPrefsAsync() {
-        this._data = await XH.fetchJson({
+        const data = await XH.fetchJson({
             url: 'xh/getPrefs',
             params: {clientUsername: XH.getUsername()}
         });
+        forEach(data, v => {
+            deepFreeze(v.value);
+            deepFreeze(v.defaultValue);
+        });
+        this._data = data;
         this.syncLocalPrefs();
     }
 
@@ -193,7 +199,9 @@ export class PrefService {
 
         for (let key in data) {
             if (data[key].local) {
-                data[key].value = !isNil(localPrefs[key]) ? localPrefs[key] : data[key].defaultValue;
+                data[key].value = !isNil(localPrefs[key]) ?
+                    deepFreeze(cloneDeep(localPrefs[key])) :
+                    data[key].defaultValue;
             }
         }
     }

--- a/svc/PrefService.js
+++ b/svc/PrefService.js
@@ -94,7 +94,7 @@ export class PrefService {
         if (isEqual(oldValue, value)) return;
 
         // Change local value to sanitized copy and fire.
-        deepFreeze(cloneDeep(value));
+        value = deepFreeze(cloneDeep(value));
         this._data[key].value = value;
         this.fireEvent('prefChange', {key, value, oldValue});
 

--- a/utils/js/LangUtils.js
+++ b/utils/js/LangUtils.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 import {XH} from '@xh/hoist/core';
-import {isObject, forOwn, mixin} from 'lodash';
+import {isObject, isObjectLike, forOwn, mixin} from 'lodash';
 import _inflection from 'lodash-inflection';
 
 mixin(_inflection);
@@ -64,4 +64,15 @@ export function warnIf(condition, message) {
 
 export function withDefault(...args) {
     return args.find(it => it !== undefined);
+}
+
+export function deepFreeze(object) {
+    // Adapted from MDN
+    if (!isObjectLike(object)) return object;
+
+    const propNames = Object.getOwnPropertyNames(object);
+    for (const name of propNames) {
+        deepFreeze(object[name]);
+    }
+    return Object.freeze(object);
 }


### PR DESCRIPTION
Note that this could represent a breaking change for any apps that are depending on the current behavior of PrefService and CloneService to clone the return from get().  These apps would simply need to do the clone themselves.  It should be a very visible and easy to fix failure.

I think this establishes a safer and more efficient pattern for shared data.

Still to do, making localStorageService freeze() as well.  This is a bit trickier.

Also, if people approve of this approach, I can go ahead and add some discussion of this in the documentation.


