### PR TITLE
Remove workaround in boolean controls to handle string values

### DIFF
--- a/desktop/cmp/form/inputs/Checkbox.js
+++ b/desktop/cmp/form/inputs/Checkbox.js
@@ -62,12 +62,7 @@ export class Checkbox extends HoistInput {
             onFocus: this.onFocus
         });
     }
-
-    // Cast "false" -> false (see Admin config editor for a sample use case).
-    toInternal(external) {
-        return (external === 'false') ? false : external;
-    }
-
+    
     onChange = (e) => {
         this.noteValueChange(e.target.checked);
     }

--- a/desktop/cmp/form/inputs/SwitchInput.js
+++ b/desktop/cmp/form/inputs/SwitchInput.js
@@ -58,12 +58,7 @@ export class SwitchInput extends HoistInput {
             onFocus: this.onFocus
         });
     }
-
-    // Cast "false" -> false (see Admin config editor for a sample use case).
-    toInternal(external) {
-        return (external === 'false') ? false : external;
-    }
-
+    
     onChange = (e) => {
         this.noteValueChange(e.target.checked);
     };


### PR DESCRIPTION
Needs branch in hoist-core merged first as well.  Hoist Core branch improves serialization of prefs and configs