### PR TITLE
Avoid mutating lookup results when adding 'null' in RestControl Select inputs. 

### DIFF
--- a/desktop/cmp/rest/impl/RestControl.js
+++ b/desktop/cmp/rest/impl/RestControl.js
@@ -93,7 +93,7 @@ export class RestControl extends Component {
 
         let options;
         if (field.lookup) {
-            options = field.lookup;
+            options = [...field.lookup];
         } else if (type == 'bool') {
             options = [true, false];
         } else {


### PR DESCRIPTION
Fixes #775