### PR TITLE
Create top-level DOM node for Select menu portal

### DIFF
--- a/core/XH.js
+++ b/core/XH.js
@@ -145,7 +145,7 @@ class XHClass {
     renderApp(appSpec) {
         this.appSpec = appSpec instanceof AppSpec ? appSpec : new AppSpec(appSpec);
         const rootView = elem(appSpec.containerClass, {model: this.appContainerModel});
-        ReactDOM.render(rootView, document.getElementById('root'));
+        ReactDOM.render(rootView, document.getElementById('xh-root'));
     }
 
     /**

--- a/desktop/cmp/form/inputs/Select.js
+++ b/desktop/cmp/form/inputs/Select.js
@@ -138,9 +138,9 @@ export class Select extends HoistInput {
                 placeholder: withDefault(props.placeholder, 'Select...'),
                 tabIndex: props.tabIndex,
 
-                // This node is written into the DOM directly within static/index.html and assigned
+                // A shared div is created lazily here as needed, appended to the body, and assigned
                 // a high z-index to ensure options menus render over dialogs or other modals.
-                menuPortalTarget: document.getElementById('xh-select-input-portal'),
+                menuPortalTarget: this.getOrCreatePortalDiv(),
 
                 inputId: props.id,
                 classNamePrefix: 'xh-select',
@@ -308,6 +308,18 @@ export class Select extends HoistInput {
     createMessageFn = (q) => {
         const {createMessageFn} = this.props;
         return createMessageFn ? createMessageFn(q) : `Create "${q}"`;
+    }
+
+    getOrCreatePortalDiv() {
+        let portal = document.getElementById('xh-select-input-portal');
+
+        if (!portal) {
+            portal = document.createElement('div');
+            portal.id = 'xh-select-input-portal';
+            document.body.appendChild(portal);
+        }
+
+        return portal;
     }
 
 }

--- a/desktop/cmp/form/inputs/Select.js
+++ b/desktop/cmp/form/inputs/Select.js
@@ -40,7 +40,6 @@ export class Select extends HoistInput {
          */
         createMessageFn: PT.func,
 
-
         /** True to accept and commit input values not present in options or returned by a query. */
         enableCreate: PT.bool,
 
@@ -135,14 +134,16 @@ export class Select extends HoistInput {
                 isDisabled: props.disabled,
                 isMulti: props.enableMulti,
                 menuPlacement: withDefault(props.menuPlacement, 'auto'),
-                menuPortalTarget: document.body,
                 noOptionsMessage: this.noOptionsMessageFn,
                 placeholder: withDefault(props.placeholder, 'Select...'),
                 tabIndex: props.tabIndex,
 
+                // This node is written into the DOM directly within static/index.html and assigned
+                // a high z-index to ensure options menus render over dialogs or other modals.
+                menuPortalTarget: document.getElementById('xh-select-input-portal'),
+
                 inputId: props.id,
                 classNamePrefix: 'xh-select',
-                styles: this.getStylesConfig(),
                 theme: this.getThemeConfig(),
 
                 onBlur: this.onBlur,
@@ -167,7 +168,6 @@ export class Select extends HoistInput {
             (this.creatableMode ? reactCreatableSelect : reactSelect);
 
         assign(rsProps, props.rsOptions);
-
 
         return box({
             item: factory(rsProps),
@@ -278,15 +278,6 @@ export class Select extends HoistInput {
     //------------------------
     // Other Implementation
     //------------------------
-    getStylesConfig() {
-        return {
-            // Support display within a dialog by boosting menu portal z-index.
-            menuPortal: (base) => {
-                return {...base, zIndex: 999};
-            }
-        };
-    }
-
     getThemeConfig() {
         return (base) => {
             return {

--- a/desktop/cmp/form/inputs/Select.scss
+++ b/desktop/cmp/form/inputs/Select.scss
@@ -1,3 +1,9 @@
+// Host div for Select option menu portal - written into DOM by static/index.html.
+#xh-select-input-portal {
+  z-index: 999;
+  position: absolute;
+}
+
 .xh-select {
   // Default width of wrapping box.
   width: 200px;

--- a/desktop/cmp/form/inputs/Select.scss
+++ b/desktop/cmp/form/inputs/Select.scss
@@ -1,4 +1,4 @@
-// Host div for Select option menu portal - written into DOM by static/index.html.
+// Host div for Select option menu portal.
 #xh-select-input-portal {
   z-index: 999;
   position: absolute;

--- a/static/index.html
+++ b/static/index.html
@@ -37,7 +37,8 @@
     You need to enable JavaScript to run this app.
   </noscript>
 
-  <div id="root"></div>
+  <div id="xh-root"></div>
+  <div id="xh-select-input-portal"></div>
 
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -38,7 +38,6 @@
   </noscript>
 
   <div id="xh-root"></div>
-  <div id="xh-select-input-portal"></div>
 
 </body>
 </html>


### PR DESCRIPTION
+ Allows us to avoid using the styles() API within the Select input component itself to control menu portal z-index (reserving that react-select prop as something an app could leverage if needed to style other aspects of its components).
+ Rename existing 'root' div to 'xh-root' to use our namespace in that context as well.