### PR TITLE
 Append (non-prod) environment to app title

### DIFF
--- a/svc/EnvironmentService.js
+++ b/svc/EnvironmentService.js
@@ -33,6 +33,8 @@ export class EnvironmentService {
 
         deepFreeze(this._data);
 
+        this.adjustDocTitleForNonProdEnv();
+
         this.addReaction({
             when: () => XH.appIsRunning,
             run: this.startVersionChecking
@@ -50,6 +52,13 @@ export class EnvironmentService {
     //------------------------------
     // Implementation
     //------------------------------
+    adjustDocTitleForNonProdEnv() {
+        const env = this.get('appEnvironment');
+        if (env != 'Production') {
+            document.title += ` (${env})`;
+        }
+    }
+
     startVersionChecking() {
         const interval = XH.getConf('xhAppVersionCheckSecs');
         Timer.create({


### PR DESCRIPTION
+ Clearly we could do this in a number of places - XH.js being a likely alternative. EnvironmentService seemed like a reasonable place, too, and that's what we have here. Could also format in various ways, make optional, etc. but didn't want to over-complicate.