### PR TITLE
Column comparator falls back to default comparator.

### DIFF
--- a/cmp/grid/columns/Column.js
+++ b/cmp/grid/columns/Column.js
@@ -9,6 +9,7 @@ import {Component} from 'react';
 import {castArray, startCase, isFunction, clone, find} from 'lodash';
 import {ExportFormat} from './ExportFormat';
 import {withDefault, throwIf, warnIf} from '@xh/hoist/utils/js';
+import {Utils as agUtils} from 'ag-grid-community';
 
 /**
  * Cross-platform definition and API for a standardized Grid column.
@@ -268,7 +269,7 @@ export class Column {
     //--------------------
     comparator = (v1, v2) => {
         const sortCfg = find(this.gridModel.sortBy, {colId: this.colId});
-        return sortCfg.comparator(v1, v2);
+        return sortCfg ? sortCfg.comparator(v1, v2) : agUtils.defaultComparator(v1, v2);
     };
 
 }

--- a/cmp/grid/impl/GridSorter.js
+++ b/cmp/grid/impl/GridSorter.js
@@ -5,7 +5,7 @@
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
 
-import {Utils} from 'ag-grid-community';
+import {Utils as agUtils} from 'ag-grid-community';
 import {isString, isNumber} from 'lodash';
 
 export class GridSorter {
@@ -61,7 +61,7 @@ export class GridSorter {
             v1 = isNumber(v1) ? Math.abs(v1) : v1;
             v2 = isNumber(v2) ? Math.abs(v2) : v2;
         }
-        return Utils.defaultComparator(v1, v2);
+        return agUtils.defaultComparator(v1, v2);
     }
 
 }


### PR DESCRIPTION
Column.comparator is used by ag-grid's column filters to sort the available options in a set filter - we should fall back to default comparator if we don't have a sorter in the GridModel.

