### PR TITLE
border-box styling for mobile

### DIFF
--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -6,6 +6,11 @@ body.xh-app {
   color: var(--xh-text-color);
   font-family: var(--xh-font-family);
   font-size: var(--xh-font-size-px);
+  box-sizing: border-box;
+
+  *, *:before, *:after {
+    box-sizing: inherit;
+  }
 
   // Important for using the body as the `popupParent` for our ag-grids
   height: 100vh;


### PR DESCRIPTION
We have relied on blueprint css to default all DOM elements to `box-sizing: border-box`. See [here](https://github.com/palantir/blueprint/blob/4e93d2f5d8965aa2864759b663c70640b589ecd0/packages/core/src/_reset.scss#L9).

Since we're no longer applying blueprint styling to the mobile app, we need to set this property ourselves.