### PR TITLE
Store filter field no store fix

### DIFF
--- a/desktop/cmp/store/StoreFilterField.js
+++ b/desktop/cmp/store/StoreFilterField.js
@@ -15,7 +15,7 @@ import {textInput} from '@xh/hoist/desktop/cmp/form';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {Icon} from '@xh/hoist/icon';
 import {BaseStore} from '@xh/hoist/data';
-import {withDefault, throwIf} from '@xh/hoist/utils/js';
+import {withDefault, throwIf, warnIf} from '@xh/hoist/utils/js';
 
 /**
  * A text input Component that generates a filter function based on simple word-boundary matching of
@@ -88,7 +88,7 @@ export class StoreFilterField extends Component {
 
         throwIf(props.gridModel && props.store, "Cannot specify both 'gridModel' and 'store' props.");
         throwIf(props.includeFields && props.excludeFields, "Cannot specify both 'includeFields' and 'excludeFields' props.");
-        throwIf(!props.gridModel && !props.store && !props.includeFields, "Must specify one of 'gridModel', 'store', or 'includeFields'");
+        warnIf(!props.gridModel && !props.store && isEmpty(props.includeFields), "Must specify one of 'gridModel', 'store', or 'includeFields' or the filter will be a no-op");
 
         const store = this.getActiveStore();
         if (store) {

--- a/desktop/cmp/store/StoreFilterField.js
+++ b/desktop/cmp/store/StoreFilterField.js
@@ -88,6 +88,7 @@ export class StoreFilterField extends Component {
 
         throwIf(props.gridModel && props.store, "Cannot specify both 'gridModel' and 'store' props.");
         throwIf(props.includeFields && props.excludeFields, "Cannot specify both 'includeFields' and 'excludeFields' props.");
+        throwIf(!props.gridModel && !props.store && !props.includeFields, "Must specify one of 'gridModel', 'store', or 'includeFields'");
 
         const store = this.getActiveStore();
         if (store) {
@@ -192,9 +193,9 @@ export class StoreFilterField extends Component {
             store = this.getActiveStore();
 
         let ret = store ? store.fields.map(f => f.name) : [];
-        if (includeFields) ret = intersection(ret, includeFields);
+        if (includeFields) ret = store ? intersection(ret, includeFields) : includeFields;
         if (excludeFields) ret = without(ret, excludeFields);
-        
+
         if (gridModel) {
             const groupBy = gridModel.groupBy,
                 columns = gridModel.getLeafColumns();


### PR DESCRIPTION
Fixes #821 

Make sure that includeFields is used if there is no store associated with the component.

Note that in Toolbox, the News grid had a bug where the store filter field would overwrite the source filter, because a store was being provided. Removing that (https://github.com/exhi/toolbox/commit/4140f328f96b565f51b88a1e15a6629d6941845b) reproduces the bug this pr fixes.
