### PR TITLE
Mobile toolbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 🎁 New Features
+
+* `Toolbar` and `ToolbarSeparator` have been added to the mobile component library.
+
 ## v16.0.0
 
 ### 🎁 New Features

--- a/mobile/cmp/toolbar/Toolbar.js
+++ b/mobile/cmp/toolbar/Toolbar.js
@@ -1,0 +1,39 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+import {Component} from 'react';
+import PT from 'prop-types';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
+import {hbox, vbox} from '@xh/hoist/cmp/layout';
+
+import './Toolbar.scss';
+
+/**
+ * A toolbar with built-in styling and padding.
+ */
+@HoistComponent
+export class Toolbar extends Component {
+    static propTypes = {
+        /** Custom classes that will be applied to this component */
+        className: PT.string,
+
+        /** Set to true to vertically align the items of this toolbar */
+        vertical: PT.bool
+    };
+
+    baseClassName = 'xh-toolbar';
+
+    render() {
+        const {vertical, ...rest} = this.props;
+
+        return (vertical ? vbox : hbox)({
+            ...rest,
+            className: this.getClassName(vertical ? 'xh-toolbar--vertical' : null)
+        });
+    }
+}
+
+export const toolbar = elemFactory(Toolbar);

--- a/mobile/cmp/toolbar/Toolbar.scss
+++ b/mobile/cmp/toolbar/Toolbar.scss
@@ -1,0 +1,58 @@
+.xh-toolbar {
+  padding: var(--xh-pad-half-px) var(--xh-pad-px) var(--xh-pad-half-px) 0;
+  color: var(--xh-tbar-text-color);
+  background-color: var(--xh-tbar-bg);
+  width: 100%;
+  flex: none;
+  align-items: center;
+  flex-wrap: nowrap;
+
+  > * {
+    white-space: nowrap;
+    flex-shrink: 0;
+
+    &:not([class*='xh-no-pad']) {
+      margin-left: var(--xh-tbar-item-pad-px);
+    }
+  }
+
+  &:not(&--vertical) {
+    &:not(:last-child) {
+      border-bottom: 1px solid var(--xh-tbar-border-color);
+    }
+
+    &:last-child {
+      border-top: 1px solid var(--xh-tbar-border-color);
+    }
+
+    .xh-toolbar__separator {
+      border-left: 1px solid var(--xh-tbar-separator-color);
+      height: 20px;
+      margin-left: calc(var(--xh-tbar-item-pad) * 2px);
+      margin-right: var(--xh-tbar-item-pad-px);
+    }
+  }
+
+  &--vertical {
+    width: 44px;
+    padding: 0 var(--xh-pad-half-px) var(--xh-pad-px) var(--xh-pad-half-px);
+
+    > *:not([class*='xh-no-pad']) {
+      margin-top: var(--xh-tbar-item-pad-px);
+      margin-left: 0;
+    }
+
+    .xh-toolbar__separator {
+      border-bottom: 1px solid var(--xh-tbar-separator-color);
+      width: 20px;
+    }
+
+    &:first-child {
+      border-right: 1px solid var(--xh-tbar-border-color);
+    }
+
+    &:last-child {
+      border-left: 1px solid var(--xh-tbar-border-color);
+    }
+  }
+}

--- a/mobile/cmp/toolbar/ToolbarSeparator.js
+++ b/mobile/cmp/toolbar/ToolbarSeparator.js
@@ -1,0 +1,31 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {Component} from 'react';
+import {HoistComponent, elemFactory} from '@xh/hoist/core';
+import {span} from '@xh/hoist/cmp/layout';
+
+import './Toolbar.scss';
+
+/**
+ * Convenience component to insert a pre-styled separator | between Toolbar items.
+ */
+@HoistComponent
+export class ToolbarSeparator extends Component {
+
+    baseClassName = 'xh-toolbar__separator';
+
+    render() {
+        return span({
+            ...this.props,
+            className: this.getClassName()
+        });
+    }
+
+}
+
+export const toolbarSep = elemFactory(ToolbarSeparator);

--- a/mobile/cmp/toolbar/index.js
+++ b/mobile/cmp/toolbar/index.js
@@ -1,0 +1,8 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+export * from './Toolbar';
+export * from './ToolbarSeparator';


### PR DESCRIPTION
Onsen's toolbars are absolutely positioned, which raises a number of issues (you can only have 1 top and / or bottom toolbar per page, they can overlap other components etc).

This change brings symmetry between the desktop and mobile toolbar implementations. Prompted by an immediate need in a client app.

Please also see Toolbox example:
https://github.com/exhi/toolbox/pull/116

<img width="390" alt="mobile toolbar example" src="https://user-images.githubusercontent.com/3017757/49245477-64099500-f40a-11e8-99a0-b0691c7c36bf.png">