### PR TITLE
Select input:  stopPropagation of key event only when menuIsOpen = true

### DIFF
--- a/desktop/cmp/form/inputs/Select.js
+++ b/desktop/cmp/form/inputs/Select.js
@@ -191,16 +191,16 @@ export class Select extends HoistInput {
             className: this.getClassName(),
             width: props.width,
             onKeyDown: (e) => {
-                // Esc. can be used within the select to clear value / dismiss dropdown menu.
-                // Catch in this wrapper box - specifically to avoid dismissing dialogs.
-                if (e.key == 'Escape' && this.reactSelectRef.current.state.menuIsOpen) e.stopPropagation();
-                // For forms that have 'save on enter' behaviour
-                if (e.key == 'Enter' && this.reactSelectRef.current.state.menuIsOpen) e.stopPropagation();
+                // Esc. and Enter can be use by other things -- stop the key propogation,
+                // only if react select already likely to have used for menu management.
+                const {menuIsOpen} = this.reactSelectRef.current.state;
+                if (menuIsOpen && (e.key == 'Escape' || e.key == 'Enter')) {
+                    e.stopPropagation();
+                }
             },
             ...this.getLayoutProps()
         });
     }
-
 
     //-------------------------
     // Options / value handling

--- a/desktop/cmp/form/inputs/Select.js
+++ b/desktop/cmp/form/inputs/Select.js
@@ -4,6 +4,7 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
+import React from 'react';
 
 import PT from 'prop-types';
 import {HoistComponent, elemFactory, LayoutSupport} from '@xh/hoist/core';
@@ -135,6 +136,8 @@ export class Select extends HoistInput {
         });
     }
 
+    reactSelectRef = React.createRef();
+
     render() {
         const {props, renderValue} = this,
             rsProps = {
@@ -160,7 +163,9 @@ export class Select extends HoistInput {
 
                 onBlur: this.onBlur,
                 onChange: this.onSelectChange,
-                onFocus: this.onFocus
+                onFocus: this.onFocus,
+
+                ref: this.reactSelectRef
             };
 
         if (this.asyncMode) {
@@ -188,7 +193,9 @@ export class Select extends HoistInput {
             onKeyDown: (e) => {
                 // Esc. can be used within the select to clear value / dismiss dropdown menu.
                 // Catch in this wrapper box - specifically to avoid dismissing dialogs.
-                if (e.key == 'Escape') e.stopPropagation();
+                if (e.key == 'Escape' && this.reactSelectRef.current.state.menuIsOpen) e.stopPropagation();
+                // For forms that have 'save on enter' behaviour
+                if (e.key == 'Enter' && this.reactSelectRef.current.state.menuIsOpen) e.stopPropagation();
             },
             ...this.getLayoutProps()
         });


### PR DESCRIPTION
Hi,

implementing this fix requires using a ref on the react select props, which will be overwritten if a user assigns their own ref via rsOptions.  

Just pointing that out for consideration.  One solution might be to only create this ref and wrap the reactSelect in a box if 'popoverMode' = true.  Happy to discuss.

-Colin