### PR TITLE
RestGrid Editable Mode

### DIFF
--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -14,12 +14,32 @@ import {fragment} from '@xh/hoist/cmp/layout';
 import {restGridToolbar} from './impl/RestGridToolbar';
 import {restForm} from './impl/RestForm';
 import {RestGridModel} from './RestGridModel';
+import PT from 'prop-types';
 
 @HoistComponent
 @LayoutSupport
 export class RestGrid extends Component {
 
     static modelClass = RestGridModel;
+
+    static propTypes = {
+        /**
+         *
+         * This constitutes an 'escape hatch' for applications that need to get to the underlying
+         * ag-Grid API.  It should be used with care. Settings made here might be overwritten and/or
+         * interfere with the implementation of this component and its use of the ag-Grid API.
+         */
+        agOptions: PT.object,
+
+        /** Optional components rendered adjacent to the top toolbar's action buttons */
+        extraToolbarItems: PT.array,
+
+        /**
+         * Callback to call when a row is double clicked. Function will receive an event
+         * with a data node containing the row's data.
+         */
+        onRowDoubleClicked: PT.func,
+    };
 
     baseClassName = 'xh-rest-grid';
 

--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -25,7 +25,7 @@ export class RestGrid extends Component {
 
     render() {
         const {model} = this,
-            {extraToolbarItems, agOptions} = this.props;
+            {extraToolbarItems, onRowDoubleClicked = this.onRowDoubleClicked, agOptions} = this.props;
 
         return fragment(
             panel({
@@ -34,7 +34,7 @@ export class RestGrid extends Component {
                 tbar: restGridToolbar({model, extraToolbarItems}),
                 item: grid({
                     model: model.gridModel,
-                    onRowDoubleClicked: this.onRowDoubleClicked,
+                    onRowDoubleClicked,
                     agOptions
                 })
             }),
@@ -47,7 +47,13 @@ export class RestGrid extends Component {
     //------------------------
     onRowDoubleClicked = (row) => {
         if (!row.data) return;
-        this.model.formModel.openEdit(row.data);
+
+        const {editable, formModel} = this.model;
+        if (editable) {
+            formModel.openEdit(row.data);
+        } else {
+            formModel.openView(row.data);
+        }
     }
 }
 export const restGrid = elemFactory(RestGrid);

--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -68,8 +68,8 @@ export class RestGrid extends Component {
     onRowDoubleClicked = (row) => {
         if (!row.data) return;
 
-        const {editable, formModel} = this.model;
-        if (editable) {
+        const {readOnly, formModel} = this.model;
+        if (!readOnly) {
             formModel.openEdit(row.data);
         } else {
             formModel.openView(row.data);

--- a/desktop/cmp/rest/RestGrid.js
+++ b/desktop/cmp/rest/RestGrid.js
@@ -68,8 +68,8 @@ export class RestGrid extends Component {
     onRowDoubleClicked = (row) => {
         if (!row.data) return;
 
-        const {readOnly, formModel} = this.model;
-        if (!readOnly) {
+        const {readonly, formModel} = this.model;
+        if (!readonly) {
             formModel.openEdit(row.data);
         } else {
             formModel.openView(row.data);

--- a/desktop/cmp/rest/RestGridModel.js
+++ b/desktop/cmp/rest/RestGridModel.js
@@ -55,7 +55,7 @@ export class RestGridModel {
     //----------------
     // Properties
     //----------------
-    readOnly;
+    readonly;
 
     toolbarActions;
     menuActions;
@@ -82,7 +82,7 @@ export class RestGridModel {
     get selectedRecord() {return this.gridModel.selectedRecord}
 
     /**
-     * @param {boolean} [readOnly] - Prevent users from creating, updating, or destroying a record. Defaults to false.
+     * @param {boolean} [readonly] - Prevent users from creating, updating, or destroying a record. Defaults to false.
      * @param {Object[]|RecordAction[]} [toolbarActions] - actions to display in the toolbar. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [menuActions] - actions to display in the grid context menu. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [formActions] - actions to display in the form toolbar. Defaults to delete.
@@ -94,10 +94,10 @@ export class RestGridModel {
      * @param {*} ...rest - arguments for GridModel.
      */
     constructor({
-        readOnly = false,
-        toolbarActions = !readOnly ? [addAction, editAction, deleteAction] : [viewAction],
-        menuActions = !readOnly ? [addAction, editAction, deleteAction] : [viewAction],
-        formActions = !readOnly ? [deleteAction] : [],
+        readonly = false,
+        toolbarActions = !readonly ? [addAction, editAction, deleteAction] : [viewAction],
+        menuActions = !readonly ? [addAction, editAction, deleteAction] : [viewAction],
+        formActions = !readonly ? [deleteAction] : [],
         actionWarning,
         unit = 'record',
         filterFields,
@@ -105,7 +105,7 @@ export class RestGridModel {
         editors = [],
         ...rest
     }) {
-        this.readOnly = readOnly;
+        this.readonly = readonly;
 
         this.toolbarActions = toolbarActions;
         this.menuActions = menuActions;
@@ -158,7 +158,7 @@ export class RestGridModel {
 
     @action
     deleteRecord(record) {
-        throwIf(this.readOnly, 'Record not deleted: this grid is read-only');
+        throwIf(this.readonly, 'Record not deleted: this grid is read-only');
         this.store.deleteRecordAsync(record)
             .then(() => this.formModel.close())
             .catchDefault();

--- a/desktop/cmp/rest/RestGridModel.js
+++ b/desktop/cmp/rest/RestGridModel.js
@@ -80,6 +80,7 @@ export class RestGridModel {
     get selectedRecord() {return this.gridModel.selectedRecord}
 
     /**
+     * @param {boolean} [editable] - make CRUD controls visible. Defaults to true.
      * @param {Object[]|RecordAction[]} [toolbarActions] - actions to display in the toolbar. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [menuActions] - actions to display in the grid context menu. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [formActions] - actions to display in the form toolbar. Defaults to delete.
@@ -91,9 +92,10 @@ export class RestGridModel {
      * @param {*} ...rest - arguments for GridModel.
      */
     constructor({
-        toolbarActions = [addAction, editAction, deleteAction],
-        menuActions = [addAction, editAction, deleteAction],
-        formActions = [deleteAction],
+        editable = true,
+        toolbarActions = editable ? [addAction, editAction, deleteAction] : [viewAction],
+        menuActions = editable ? [addAction, editAction, deleteAction] : [viewAction],
+        formActions = editable ? [deleteAction] : [],
         actionWarning,
         unit = 'record',
         filterFields,

--- a/desktop/cmp/rest/RestGridModel.js
+++ b/desktop/cmp/rest/RestGridModel.js
@@ -82,7 +82,7 @@ export class RestGridModel {
     get selectedRecord() {return this.gridModel.selectedRecord}
 
     /**
-     * @param {boolean} [readOnly] - allow users to create, update, or destroy a record. Defaults to true.
+     * @param {boolean} [readOnly] - Prevent users from creating, updating, or destroying a record. Defaults to false.
      * @param {Object[]|RecordAction[]} [toolbarActions] - actions to display in the toolbar. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [menuActions] - actions to display in the grid context menu. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [formActions] - actions to display in the form toolbar. Defaults to delete.

--- a/desktop/cmp/rest/RestGridModel.js
+++ b/desktop/cmp/rest/RestGridModel.js
@@ -80,7 +80,7 @@ export class RestGridModel {
     get selectedRecord() {return this.gridModel.selectedRecord}
 
     /**
-     * @param {boolean} [editable] - make CRUD controls visible. Defaults to true.
+     * @param {boolean} [editable] - allow users to create, update, or destroy a record. Defaults to true.
      * @param {Object[]|RecordAction[]} [toolbarActions] - actions to display in the toolbar. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [menuActions] - actions to display in the grid context menu. Defaults to add, edit, delete.
      * @param {Object[]|RecordAction[]} [formActions] - actions to display in the form toolbar. Defaults to delete.

--- a/desktop/cmp/rest/impl/RestFormModel.js
+++ b/desktop/cmp/rest/impl/RestFormModel.js
@@ -66,6 +66,7 @@ export class RestFormModel {
     //-----------------
     @action
     saveRecord() {
+        throwIf(this.parent.readOnly, 'Record not saved: this grid is read-only.');
         const {isAdd, record, store} = this;
         start(() => {
             return isAdd ? store.addRecordAsync(record) : store.saveRecordAsync(record);

--- a/desktop/cmp/rest/impl/RestFormModel.js
+++ b/desktop/cmp/rest/impl/RestFormModel.js
@@ -66,7 +66,7 @@ export class RestFormModel {
     //-----------------
     @action
     saveRecord() {
-        throwIf(this.parent.readOnly, 'Record not saved: this grid is read-only.');
+        throwIf(this.parent.readonly, 'Record not saved: this grid is read-only.');
         const {isAdd, record, store} = this;
         start(() => {
             return isAdd ? store.addRecordAsync(record) : store.saveRecordAsync(record);


### PR DESCRIPTION
For #869 

- RestGrid takes an editable prop with default = true
- RestGrid.editable controls default menu buttons
- allow onRowDoubleClicked prop
- rowDoubleClicked defaults to edit if editable, view if not