### PR TITLE
Display datasource info in Admin (Fixes hoist-react #829)

### DIFF
--- a/admin/tabs/general/about/AboutPanel.js
+++ b/admin/tabs/general/about/AboutPanel.js
@@ -45,7 +45,10 @@ export class AboutPanel extends Component {
                     row('Environment', svc.get('appEnvironment')),
                     row('Server', svc.get('appVersion')),
                     row('Client', svc.get('clientVersion')),
-                    row('Build', svc.get('clientBuild'))
+                    row('Build', svc.get('clientBuild')),
+                    row('DB', svc.get('databaseConnectionString')),
+                    row('DB User', svc.get('databaseUser')),
+                    row('DB Create Mode', svc.get('databaseCreateMode'))
                 )
             }),
             h2('Framework Versions'),


### PR DESCRIPTION
This is implemented with the following choices:
The new datasource info (NDI) comes in on the /xh/environment endpoint only if the user is an admin user.
The NDI is not displayed on mobile.  Seems like when someone wants to know this, they will be debugging at a desktop, and we should save space on mobile.

The NDI presents 3 props: 
databaseConnectionString
databaseCreateMode
databaseUser

See also hoist-core PR: https://github.com/exhi/hoist-core/pull/67