### PR TITLE
Admin grids cleanup

### DIFF
--- a/admin/tabs/activity/clienterrors/ClientErrorModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorModel.js
@@ -11,6 +11,7 @@ import {action, observable} from '@xh/hoist/mobx';
 import {LocalStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtDate} from '@xh/hoist/format';
+import {span} from '@xh/hoist/cmp/layout';
 import {boolCheckCol, compactDateCol} from '@xh/hoist/cmp/grid/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
@@ -48,7 +49,7 @@ export class ClientErrorModel {
             {field: 'device', width: 100},
             {field: 'appVersion', width: 130},
             {field: 'appEnvironment', headerName: 'Environment', width: 130},
-            {field: 'error', flex: true, minWidth: 150, elementRenderer: (e) => <span>{e}</span>}
+            {field: 'error', flex: true, minWidth: 150, renderer: (e) => `<span>${e}</span>`}
         ]
     });
 

--- a/admin/tabs/activity/clienterrors/ClientErrorModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorModel.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-
+import React from 'react';
 import moment from 'moment';
 import {XH, HoistModel} from '@xh/hoist/core';
 import {action, observable} from '@xh/hoist/mobx';
@@ -13,6 +13,7 @@ import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtDate} from '@xh/hoist/format';
 import {boolCheckCol, compactDateCol} from '@xh/hoist/cmp/grid/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 @HoistModel
 export class ClientErrorModel {
@@ -23,6 +24,9 @@ export class ClientErrorModel {
     @observable error = '';
 
     @observable detailRecord = null;
+
+    loadModel = new PendingTaskModel();
+
 
     gridModel = new GridModel({
         stateModel: 'xhClientErrorGrid',
@@ -44,7 +48,7 @@ export class ClientErrorModel {
             {field: 'device', width: 100},
             {field: 'appVersion', width: 130},
             {field: 'appEnvironment', headerName: 'Environment', width: 130},
-            {field: 'error', flex: true, minWidth: 150}
+            {field: 'error', flex: true, minWidth: 150, elementRenderer: (e) => <span>{e}</span>}
         ]
     });
 
@@ -54,7 +58,9 @@ export class ClientErrorModel {
             params: this.getParams()
         }).then(data => {
             this.gridModel.loadData(data);
-        }).catchDefault();
+        }).linkTo(
+            this.loadModel
+        ).catchDefault();
     }
 
     adjustDates(dir, toToday = false) {

--- a/admin/tabs/activity/clienterrors/ClientErrorPanel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorPanel.js
@@ -26,6 +26,7 @@ export class ClientErrorPanel extends Component {
     render() {
         const {model} = this;
         return panel({
+            mask: model.loadModel,
             tbar: this.renderToolbar(),
             items: [
                 grid({

--- a/admin/tabs/activity/feedback/FeedbackPanel.js
+++ b/admin/tabs/activity/feedback/FeedbackPanel.js
@@ -53,6 +53,7 @@ export class FeedbackPanel extends Component {
         menuActions: [deleteAction],
         formActions: [deleteAction],
         unit: 'report',
+        sortBy: {colId: 'dateCreated', sort: 'desc'},
         filterFields: ['username', 'msg'],
         columns: [
             {field: 'dateCreated', ...compactDateCol, width: 140},

--- a/admin/tabs/activity/tracking/ActivityGrid.js
+++ b/admin/tabs/activity/tracking/ActivityGrid.js
@@ -23,6 +23,7 @@ export class ActivityGrid extends Component {
     render() {
         const {model} = this;
         return panel({
+            mask: model.loadModel,
             tbar: this.renderToolbar(),
             items: [
                 grid({

--- a/admin/tabs/activity/tracking/ActivityGridModel.js
+++ b/admin/tabs/activity/tracking/ActivityGridModel.js
@@ -12,6 +12,7 @@ import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {dateTimeCol} from '@xh/hoist/cmp/grid/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 @HoistModel
 export class ActivityGridModel {
@@ -25,6 +26,8 @@ export class ActivityGridModel {
     @observable browser = '';
 
     @observable detailRecord = null;
+
+    loadModel = new PendingTaskModel();
 
     gridModel = new GridModel({
         stateModel: 'xhActivityGrid',
@@ -64,7 +67,9 @@ export class ActivityGridModel {
             params: this.getParams()
         }).then(data => {
             this.gridModel.loadData(data);
-        }).catchDefault();
+        }).linkTo(
+            this.loadModel
+        ).catchDefault();
     }
 
     adjustDates(dir, toToday = false) {

--- a/admin/tabs/activity/tracking/VisitsChart.js
+++ b/admin/tabs/activity/tracking/VisitsChart.js
@@ -18,10 +18,12 @@ import {Icon} from '@xh/hoist/icon';
 export class VisitsChart extends Component {
     
     render() {
+        const {model} = this;
         return panel({
+            mask: model.loadModel,
             icon: Icon.users(),
             title: 'Unique Daily Visitors',
-            item: chart({model: this.model.chartModel}),
+            item: chart({model: model.chartModel}),
             bbar: this.renderToolbar(),
             model: {
                 defaultSize: 500,

--- a/admin/tabs/activity/tracking/VisitsChartModel.js
+++ b/admin/tabs/activity/tracking/VisitsChartModel.js
@@ -10,6 +10,7 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {observable, action} from '@xh/hoist/mobx';
 import {ChartModel} from '@xh/hoist/desktop/cmp/chart';
 import {fmtDate} from '@xh/hoist/format';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 @HoistModel
 export class VisitsChartModel {
@@ -17,6 +18,8 @@ export class VisitsChartModel {
     @observable startDate = moment().subtract(3, 'months').toDate();
     @observable endDate = new Date();
     @observable username = '';
+
+    loadModel = new PendingTaskModel();
 
     chartModel = new ChartModel({
         config: {
@@ -54,7 +57,9 @@ export class VisitsChartModel {
             }
         }).then(data => {
             this.chartModel.setSeries(this.getSeriesData(data));
-        }).catchDefault();
+        }).linkTo(
+            this.loadModel
+        ).catchDefault();
     }
 
     @action

--- a/admin/tabs/general/ehcache/EhCacheModel.js
+++ b/admin/tabs/general/ehcache/EhCacheModel.js
@@ -9,10 +9,13 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {UrlStore} from '@xh/hoist/data';
 import {emptyFlexCol, numberCol} from '@xh/hoist/cmp/grid/columns';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 
 @HoistModel
 export class EhCacheModel {
+
+    loadModel = new PendingTaskModel();
 
     gridModel = new GridModel({
         stateModel: 'xhEhCacheGrid',
@@ -46,7 +49,7 @@ export class EhCacheModel {
     }
 
     async loadAsync() {
-        return this.gridModel.loadAsync();
+        return this.gridModel.loadAsync().linkTo(this.loadModel);
     }
 
     destroy() {

--- a/admin/tabs/general/ehcache/EhCachePanel.js
+++ b/admin/tabs/general/ehcache/EhCachePanel.js
@@ -22,9 +22,12 @@ export class EhCachePanel extends Component {
     model = new EhCacheModel();
 
     render() {
+        const {model} = this;
+
         return panel({
+            mask: model.loadModel,
             tbar: this.renderToolbar(),
-            item: grid({model: this.model.gridModel})
+            item: grid({model: model.gridModel})
         });
     }
 

--- a/admin/tabs/general/services/ServiceModel.js
+++ b/admin/tabs/general/services/ServiceModel.js
@@ -8,9 +8,12 @@ import {XH, HoistModel} from '@xh/hoist/core';
 import {UrlStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {lowerFirst} from 'lodash';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 @HoistModel
 export class ServiceModel {
+
+    loadModel = new PendingTaskModel();
 
     gridModel = new GridModel({
         enableExport: true,
@@ -23,7 +26,7 @@ export class ServiceModel {
         sortBy: 'displayName',
         groupBy: 'provider',
         columns: [
-            {field: 'provider', width: 100},
+            {field: 'provider', width: 100, hidden: true},
             {field: 'displayName', minWidth: 300, flex: true}
         ]
     });
@@ -47,7 +50,7 @@ export class ServiceModel {
     }
 
     async loadAsync() {
-        return this.gridModel.loadAsync();
+        return this.gridModel.loadAsync().linkTo(this.loadModel);
     }
 
     processRawData(r) {

--- a/admin/tabs/general/services/ServiceModel.js
+++ b/admin/tabs/general/services/ServiceModel.js
@@ -26,7 +26,7 @@ export class ServiceModel {
         sortBy: 'displayName',
         groupBy: 'provider',
         columns: [
-            {field: 'provider', width: 100, hidden: true},
+            {field: 'provider', hidden: true},
             {field: 'displayName', minWidth: 300, flex: true}
         ]
     });

--- a/admin/tabs/general/services/ServicePanel.js
+++ b/admin/tabs/general/services/ServicePanel.js
@@ -9,8 +9,8 @@ import {HoistComponent} from '@xh/hoist/core';
 import {grid} from '@xh/hoist/cmp/grid';
 import {filler} from '@xh/hoist/cmp/layout';
 import {panel} from '@xh/hoist/desktop/cmp/panel';
-import {toolbar, toolbarSep} from '@xh/hoist/desktop/cmp/toolbar';
-import {refreshButton, button} from '@xh/hoist/desktop/cmp/button';
+import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
+import {button} from '@xh/hoist/desktop/cmp/button';
 import {storeCountLabel, storeFilterField} from '@xh/hoist/desktop/cmp/store';
 import {Icon} from '@xh/hoist/icon';
 import {ServiceModel} from './ServiceModel';
@@ -21,10 +21,13 @@ export class ServicePanel extends Component {
     model = new ServiceModel();
 
     render() {
+        const {model} = this;
+
         return panel({
+            mask: model.loadModel,
             tbar: this.renderToolbar(),
             item: grid({
-                model: this.model.gridModel,
+                model: model.gridModel,
                 hideHeaders: true,
                 agOptions: {
                     groupRowInnerRenderer: this.groupRowInnerRenderer
@@ -43,8 +46,6 @@ export class ServicePanel extends Component {
                 onClick: this.onClearCachesClick,
                 disabled: gridModel.selModel.isEmpty
             }),
-            toolbarSep(),
-            refreshButton({model}),
             filler(),
             storeCountLabel({gridModel, unit: 'service'}),
             storeFilterField({gridModel})

--- a/admin/tabs/general/users/UserModel.js
+++ b/admin/tabs/general/users/UserModel.js
@@ -13,11 +13,14 @@ import {boolCheckCol} from '@xh/hoist/cmp/grid/columns';
 import {usernameCol} from '@xh/hoist/admin/columns';
 import {bindable, action} from '@xh/hoist/mobx/index';
 import {keyBy, keys} from 'lodash';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 @HoistModel
 export class UserModel {
 
     @bindable activeOnly = true;
+
+    loadModel = new PendingTaskModel();
 
     gridModel = new GridModel({
         stateModel: 'xhUserGrid',
@@ -70,7 +73,9 @@ export class UserModel {
             });
 
             this.gridModel.loadData(users);
-        }).catchDefault();
+        }).linkTo(
+            this.loadModel
+        ).catchDefault();
     }
 }
 

--- a/admin/tabs/general/users/UserPanel.js
+++ b/admin/tabs/general/users/UserPanel.js
@@ -12,6 +12,8 @@ import {panel} from '@xh/hoist/desktop/cmp/panel';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
 import {storeCountLabel, storeFilterField} from '@xh/hoist/desktop/cmp/store';
 import {switchInput} from '@xh/hoist/desktop/cmp/form';
+import {exportButton} from '@xh/hoist/desktop/cmp/button';
+
 
 import {UserModel} from './UserModel';
 
@@ -21,10 +23,12 @@ export class UserPanel extends Component {
     model = new UserModel();
 
     render() {
+        const {model} = this;
         return panel({
+            mask: model.loadModel,
             tbar: this.renderToolbar(),
             item: grid({
-                model: this.model.gridModel
+                model: model.gridModel
             })
         });
     }
@@ -40,7 +44,8 @@ export class UserPanel extends Component {
             }),
             filler(),
             storeCountLabel({gridModel, unit: 'user'}),
-            storeFilterField({gridModel})
+            storeFilterField({gridModel}),
+            exportButton({gridModel})
         );
     }
 

--- a/admin/tabs/monitor/MonitorResultsPanel.js
+++ b/admin/tabs/monitor/MonitorResultsPanel.js
@@ -13,20 +13,23 @@ import {monitorResultsDisplay} from './MonitorResultsDisplay';
 import {MonitorResultsModel} from './MonitorResultsModel';
 
 import './MonitorResultsPanel.scss';
+import {PendingTaskModel} from '@xh/hoist/utils/async';
 
 
 @HoistComponent
 export class MonitorResultsPanel extends Component {
     model = new MonitorResultsModel({view: this});
+    loadModel = new PendingTaskModel();
 
     async loadAsync() {
-        this.model.loadAsync();
+        this.model.loadAsync().linkTo(this.loadModel);
     }
 
     render() {
-        const {model} = this;
+        const {model, loadModel} = this;
 
         return panel({
+            mask: loadModel,
             className: 'xh-monitor-results-panel',
             tbar: monitorResultsToolbar({model}),
             item: monitorResultsDisplay({model})

--- a/admin/tabs/preferences/PreferencePanel.js
+++ b/admin/tabs/preferences/PreferencePanel.js
@@ -76,7 +76,7 @@ export class PreferencePanel extends Component {
             {field: 'name', width: 200},
             {field: 'type', width: 100},
             {field: 'defaultValue', width: 200},
-            {field: 'groupName', headerName: 'Group', width: 100},
+            {field: 'groupName', headerName: 'Group', width: 100, hidden: true},
             {field: 'notes', minWidth: 200, flex: true}
         ],
         editors: [

--- a/admin/tabs/preferences/PreferencePanel.js
+++ b/admin/tabs/preferences/PreferencePanel.js
@@ -76,7 +76,7 @@ export class PreferencePanel extends Component {
             {field: 'name', width: 200},
             {field: 'type', width: 100},
             {field: 'defaultValue', width: 200},
-            {field: 'groupName', headerName: 'Group', width: 100, hidden: true},
+            {field: 'groupName', hidden: true},
             {field: 'notes', minWidth: 200, flex: true}
         ],
         editors: [

--- a/admin/tabs/preferences/UserPreferencePanel.js
+++ b/admin/tabs/preferences/UserPreferencePanel.js
@@ -66,7 +66,7 @@ export class UserPreferencePanel extends Component {
             {field: 'name', width: 200},
             {field: 'type', width: 100},
             {field: 'username', ...usernameCol},
-            {field: 'groupName', headerName: 'Group', width: 100},
+            {field: 'groupName', headerName: 'Group', width: 100, hidden: true},
             {field: 'userValue', minWidth: 200, flex: true}
         ],
         editors: [

--- a/admin/tabs/preferences/UserPreferencePanel.js
+++ b/admin/tabs/preferences/UserPreferencePanel.js
@@ -66,7 +66,7 @@ export class UserPreferencePanel extends Component {
             {field: 'name', width: 200},
             {field: 'type', width: 100},
             {field: 'username', ...usernameCol},
-            {field: 'groupName', headerName: 'Group', width: 100, hidden: true},
+            {field: 'groupName', hidden: true},
             {field: 'userValue', minWidth: 200, flex: true}
         ],
         editors: [


### PR DESCRIPTION
- hide groupBy columns
- remove unnecessary buttons
- mask to non-RestGrid panels
-renderer for client errors 'error' field