### PR TITLE
Update Highcharts to v7.0.1 (Fixes hoist-react #853)

### DIFF
--- a/desktop/cmp/chart/Chart.js
+++ b/desktop/cmp/chart/Chart.js
@@ -6,15 +6,24 @@
  */
 import {Component} from 'react';
 import {castArray, clone, merge} from 'lodash';
+import Highcharts from 'highcharts/highstock';
+import highchartsExporting from 'highcharts/modules/exporting';
+import highchartsOfflineExporting from 'highcharts/modules/offline-exporting';
+import highchartsExportData from 'highcharts/modules/export-data';
+
 import {XH, elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {div, box} from '@xh/hoist/cmp/layout';
 import {Ref} from '@xh/hoist/utils/react';
-import Highcharts from 'highcharts/highstock';
 
 import {LightTheme} from './theme/Light';
 import {DarkTheme} from './theme/Dark';
 
 import {ChartModel} from './ChartModel';
+
+highchartsExporting(Highcharts);
+highchartsOfflineExporting(Highcharts);
+highchartsExportData(Highcharts);
+
 
 /**
  * Wrapper Component for a Highcharts chart. Provides basic rendering / lifecycle management
@@ -89,6 +98,7 @@ export class Chart extends Component {
 
     getDefaultConfig() {
         const exporting = {
+            enabled: false,
             fallbackToExportServer: false,
             chartOptions: {
                 scrollbar: {enabled: false}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clipboard": "~2.0.4",
     "codemirror": "~5.42.0",
     "downloadjs": "^1.4.7",
-    "highcharts": "~6.2.0",
+    "highcharts": "~7.0.1",
     "lodash-inflection": "~1.5.0",
     "mobx": "~5.8.0",
     "mobx-react": "~5.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3999,10 +3999,10 @@ he@1.2.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highcharts@~6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-6.2.0.tgz#2a6d04652eb43c66f462ca7e2d2808f1f2782b61"
-  integrity sha512-A4E89MA+kto8giic7zyLU6ZxfXnVeCUlKOyzFsah3+n4BROx4bgonl92KIBtwLud/mIWir8ahqhuhe2by9LakQ==
+highcharts@~7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.0.1.tgz#0c6ad096559aca723bc95276bce02b9790c444e8"
+  integrity sha512-dB+BuvIt6q2e4M0MgBClOA5FbNqfOpq/hoqQOLBVBSCqXOoCHd2fgEPFuruuyTf6KqiaIKjbRJ4JZd1fImEBYg==
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Also Fixed chart exporting.
Exporting is now disabled by default.
