### PR TITLE
Fix to Panel Resizing

### DIFF
--- a/desktop/cmp/panel/impl/ResizeContainer.js
+++ b/desktop/cmp/panel/impl/ResizeContainer.js
@@ -38,10 +38,13 @@ export class ResizeContainer extends Component {
             items.push(dragger({model}));
         }
 
-        const cmp = vertical ? vbox : hbox;
+        const cmp = vertical ? vbox : hbox,
+            maxDim = vertical ? 'maxHeight' : 'maxWidth';
+
         return cmp({
             className: this.getClassName(),
             flex: 'none',
+            [maxDim]: '100%',
             items
         });
     }


### PR DESCRIPTION
Fixes https://github.com/exhi/hoist-react/issues/685

I don't think this is the last word in panel resizing by any means -- in particular, would like to have a better way for components that are layout siblings with a resizer to declare a minimum-size (based on their own header or splitter) so they don't get completely overwhelmed.

But in any case, this prevents the horrible situation of any particular resize container going beyond the bounds of its own parent.