### PR TITLE
Enforce standard placeholder color across all xh inputs, mobile/desktop

### DIFF
--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -37,7 +37,7 @@
     }
 
     &__placeholder {
-      color: rgb(175, 183, 191);
+      color: var(--xh-input-placeholder-text-color);
     }
 
     &__single-value,

--- a/desktop/cmp/input/Select.scss
+++ b/desktop/cmp/input/Select.scss
@@ -36,6 +36,10 @@
       }
     }
 
+    &__placeholder {
+      color: rgb(175, 183, 191);
+    }
+
     &__single-value,
     &__input {
       color: var(--xh-input-text-color);

--- a/kit/onsen/styles.scss
+++ b/kit/onsen/styles.scss
@@ -26,7 +26,7 @@
     text-align: inherit;
 
     &::placeholder {
-      color: rgb(175, 183, 191);
+      color: var(--xh-input-placeholder-text-color);
     }
   }
 

--- a/kit/onsen/styles.scss
+++ b/kit/onsen/styles.scss
@@ -24,6 +24,10 @@
     border: none !important;
     outline: none !important;
     text-align: inherit;
+
+    &::placeholder {
+      color: rgb(175, 183, 191);
+    }
   }
 
   &:not(.xh-input-label) {

--- a/mobile/cmp/input/Select.scss
+++ b/mobile/cmp/input/Select.scss
@@ -20,6 +20,10 @@
       min-height: 30px;
     }
 
+    &__placeholder {
+      color: rgb(175, 183, 191);
+    }
+
     &__single-value,
     &__input {
       color: var(--xh-input-text-color);

--- a/mobile/cmp/input/Select.scss
+++ b/mobile/cmp/input/Select.scss
@@ -21,7 +21,7 @@
     }
 
     &__placeholder {
-      color: rgb(175, 183, 191);
+      color: var(--xh-input-placeholder-text-color);
     }
 
     &__single-value,

--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -24,7 +24,7 @@ body.xh-app {
   }
 
   ::-webkit-input-placeholder {
-    color: rgb(175, 183, 191);
+    color: var(--xh-input-placeholder-text-color);
   }
 
   ::-webkit-scrollbar-corner {

--- a/styles/XH.scss
+++ b/styles/XH.scss
@@ -23,6 +23,10 @@ body.xh-app {
     height: 10px;
   }
 
+  ::-webkit-input-placeholder {
+    color: rgb(175, 183, 191);
+  }
+
   ::-webkit-scrollbar-corner {
     background-color: var(--xh-scrollbar-bg);
   }

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -124,6 +124,7 @@ body {
   --xh-input-disabled-bg: var(--form-field-disabled-bg, rgba(206, 217, 224, 0.5));  // This and below currently matched from Blueprint defaults
   --xh-input-disabled-text-color: var(--form-field-disabled-text-color, rgba(92, 112, 128, 0.5));
   --xh-input-text-color: var(--input-text-color, var(--xh-text-color));
+  --xh-input-placeholder-text-color: var(--input-placeholder-color, rgb(175, 183, 191));
 
   // Form fields
   --xh-form-field-box-shadow-color-top: var(--form-field-box-shadow-color-top, #{mc-trans('blue-grey', '100', 0.15)});


### PR DESCRIPTION
For #782 - using color picker tool, determined that the default input placeholder (Mac, Chrome) is rgb(175, 183, 191). Rather than try to set `select`'s placeholder color for each browser/device, thought it would be better to enforce placeholder color across all XH inputs. Used `::-webkit-input-placeholder` selector for that purpose.

Signed-off-by: shravnk <brendan.ode4@gmail.com>