### PR TITLE
Dialog text overflow

### DIFF
--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -101,6 +101,10 @@
       margin-right: var(--xh-pad-px);
     }
   }
+
+  .bp3-dialog-body {
+    word-break: break-all;
+  }
 }
 
 .bp3-dialog-container {
@@ -172,6 +176,10 @@
   }
   &.bp3-intent-warning {
     background-color: var(--xh-intent-warning);
+  }
+
+  .bp3-toast-message {
+    word-break: break-all;
   }
 }
 


### PR DESCRIPTION
Two css tweaks to handle #862. Note that I used `break-all` instead of `break-word`. Think it looks better at least in the case of error messages, i.e. not forcing very long strings to occupy a new line.