### PR TITLE
Resize columns after tree grid expand/collapse

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -170,6 +170,7 @@ export class Grid extends Component {
             overlayNoRowsTemplate: model.emptyText || '<span></span>',
             onRowClicked: props.onRowClicked,
             onRowDoubleClicked: props.onRowDoubleClicked,
+            onRowGroupOpened: this.onRowGroupOpened,
             onGridReady: this.onGridReady,
             onSelectionChanged: this.onSelectionChanged,
             onGridSizeChanged: this.onGridSizeChanged,
@@ -488,6 +489,10 @@ export class Grid extends Component {
         if (ev.source !== 'api' && ev.source !== 'uiColumnDragged') {
             this.model.setGroupBy(ev.columnApi.getRowGroupColumns().map(it => it.colId));
         }
+    };
+
+    onRowGroupOpened = () => {
+        this.model.agApi.sizeColumnsToFit();
     };
 
     // Catches column visibility changes triggered from ag-grid ui components

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -271,6 +271,7 @@ export class GridModel {
         const {agApi} = this;
         if (agApi) {
             agApi.expandAll();
+            agApi.sizeColumnsToFit();
         }
     }
 
@@ -279,6 +280,7 @@ export class GridModel {
         const {agApi} = this;
         if (agApi) {
             agApi.collapseAll();
+            agApi.sizeColumnsToFit();
         }
     }
 


### PR DESCRIPTION
For #785. If we wanted to handle this all in one place, could also use ag api's onModelUpdated

Signed-off-by: shravnk <brendan.ode4@gmail.com>