### PR TITLE
RestStore returns the new Record after a save

### DIFF
--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -7,7 +7,7 @@
 
 import {XH} from '@xh/hoist/core';
 import {UrlStore, Record} from '@xh/hoist/data';
-import {pickBy} from 'lodash';
+import {pickBy, filter} from 'lodash';
 
 import {RestField} from './RestField';
 
@@ -56,11 +56,13 @@ export class RestStore extends UrlStore {
     }
 
     async addRecordAsync(rec) {
-        return this.saveRecordInternalAsync(rec, true);
+        return this.saveRecordInternalAsync(rec, true)
+            .linkTo(this.loadModel);
     }
 
     async saveRecordAsync(rec) {
-        return this.saveRecordInternalAsync(rec, false);
+        return this.saveRecordInternalAsync(rec, false)
+            .linkTo(this.loadModel);
     }
 
     //--------------------------------
@@ -71,24 +73,21 @@ export class RestStore extends UrlStore {
         if (!isAdd) url += '/' + rec.id;
 
         // Only include editable fields in the request data
-        const editableFields = this.fields.filter(it => it.editable).map(it => it.name),
+        const editableFields = filter(this.fields, 'editable').map(it => it.name),
             data = pickBy(rec, (v, k) => k == 'id' || editableFields.includes(k));
 
-        return XH.fetchService[isAdd ? 'postJson' : 'putJson']({
-            url,
-            body: {data}
-        }).then(response => {
-            const newRec = new Record({fields: this.fields, raw: response.data});
-            if (isAdd) {
-                this.addRecordInternal(newRec);
-            } else {
-                this.updateRecordInternal(rec, newRec);
-            }
+        const fetchMethod = isAdd ? 'postJson' : 'putJson',
+            response = await XH.fetchService[fetchMethod]({url, body: {data}}),
+            newRec = new Record({fields: this.fields, raw: response.data});
 
-            return this.ensureLookupsLoadedAsync().then(() => newRec);
-        }).linkTo(
-            this.loadModel
-        );
+        if (isAdd) {
+            this.addRecordInternal(newRec);
+        } else {
+            this.updateRecordInternal(rec, newRec);
+        }
+
+        await this.ensureLookupsLoadedAsync();
+        return newRec;
     }
 
     async ensureLookupsLoadedAsync() {

--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -84,8 +84,8 @@ export class RestStore extends UrlStore {
             } else {
                 this.updateRecordInternal(rec, newRec);
             }
-        }).then(() => {
-            return this.ensureLookupsLoadedAsync();
+
+            return this.ensureLookupsLoadedAsync().then(() => newRec);
         }).linkTo(
             this.loadModel
         );


### PR DESCRIPTION
Pretty common need when using a RestStore outside the context of a RestGrid (or grid in general) is to be able to get a reference to the new Record that was just saved/added. I specifically ran into this when doing a "Save As.." type of operation and I wanted to update the selection to the new Record after the save operation completed.