### PR TITLE
Add excludeHidden opt to GridModel.getLeafColumns()

### DIFF
--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -416,21 +416,24 @@ export class GridModel {
 
     /**
      * Return all leaf-level columns - i.e. excluding column groups.
-     * @param {Object} [opts]
-     * @param {boolean} [opts.excludeHidden] - true to return currently-visible leaves only.
      * @returns {Column[]}
      */
-    getLeafColumns({excludeHidden = false} = {}) {
-        let ret = this.gatherLeaves(this.columns);
+    getLeafColumns() {
+        return this.gatherLeaves(this.columns);
+    }
 
-        if (excludeHidden) {
-            ret = ret.filter(col => {
-                const state = this.getStateForColumn(col.colId);
-                return !state || !state.hidden;
-            });
-        }
-
-        return ret;
+    /**
+     * Determine whether or not a given leaf-level column is currently visible.
+     *
+     * Call this method instead of inspecting the `hidden` property on the Column itself, as that
+     * property is not updated with state changes.
+     *
+     * @param {String} colId
+     * @returns {boolean}
+     */
+    isColumnVisible(colId) {
+        const state = this.getStateForColumn(colId);
+        return state ? !state.hidden : false;
     }
 
     /**

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -427,7 +427,7 @@ export class GridModel {
             ret = ret.filter(col => {
                 const state = this.getStateForColumn(col.colId);
                 return !state || !state.hidden;
-            })
+            });
         }
 
         return ret;

--- a/desktop/cmp/grid/impl/ColChooserModel.js
+++ b/desktop/cmp/grid/impl/ColChooserModel.js
@@ -70,15 +70,15 @@ export class ColChooserModel {
         const {gridModel, lrModel} = this;
 
         const data = gridModel.getLeafColumns().map(it => {
-            const state = gridModel.getStateForColumn(it.colId);
+            const visible = gridModel.isColumnVisible(it.colId);
             return {
                 value: it.colId,
                 text: it.chooserName,
                 description: it.chooserDescription,
                 group: it.chooserGroup,
                 exclude: it.excludeFromChooser,
-                locked: !state.hidden && !it.hideable,
-                side: state.hidden ? 'left' : 'right'
+                locked: visible && !it.hideable,
+                side: visible ? 'right' : 'left'
             };
         });
 

--- a/desktop/cmp/store/StoreFilterField.js
+++ b/desktop/cmp/store/StoreFilterField.js
@@ -194,7 +194,9 @@ export class StoreFilterField extends Component {
 
         if (gridModel) {
             const groupBy = gridModel.groupBy,
-                visibleCols = gridModel.getLeafColumns({excludeHidden: true});
+                visibleCols = gridModel
+                    .getLeafColumns()
+                    .filter(col => gridModel.isColumnVisible(col.colId));
 
             ret = ret.filter(f => {
                 return (

--- a/desktop/cmp/store/StoreFilterField.js
+++ b/desktop/cmp/store/StoreFilterField.js
@@ -177,7 +177,7 @@ export class StoreFilterField extends Component {
 
     onClearClick = () => {
         this.setValue('', {applyImmediately: true});
-    }
+    };
 
     getActiveStore() {
         const {gridModel, store} = this.props;
@@ -194,12 +194,14 @@ export class StoreFilterField extends Component {
 
         if (gridModel) {
             const groupBy = gridModel.groupBy,
-                columns = gridModel.getLeafColumns();
+                visibleCols = gridModel.getLeafColumns({excludeHidden: true});
 
             ret = ret.filter(f => {
-                return (includeFields && includeFields.includes(f)) ||
-                        columns.find(c => (c.field == f && !c.hidden)) ||
-                        groupBy.includes(f);
+                return (
+                    (includeFields && includeFields.includes(f)) ||
+                    visibleCols.find(c => c.field == f) ||
+                    groupBy.includes(f)
+                );
             });
         }
         return ret;

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -41,7 +41,7 @@ export class GridExportService {
 
         if (isFunction(filename)) filename = filename(gridModel);
 
-        const columns = this.getExportableColumns(gridModel.getLeafColumns(), includeHiddenCols),
+        const columns = this.getExportableColumns(gridModel, includeHiddenCols),
             records = gridModel.store.rootRecords,
             meta = this.getColumnMetadata(columns),
             rows = [];
@@ -95,8 +95,10 @@ export class GridExportService {
     //-----------------------
     // Implementation
     //-----------------------
-    getExportableColumns(columns, includeHiddenColumns) {
-        return columns.filter(it => !it.excludeFromExport && (!it.hidden || includeHiddenColumns));
+    getExportableColumns(gridModel, includeHiddenColumns) {
+        return gridModel
+            .getLeafColumns({excludeHidden: !includeHiddenColumns})
+            .filter(col => !col.excludeFromExport);
     }
 
     getColumnMetadata(columns) {

--- a/svc/GridExportService.js
+++ b/svc/GridExportService.js
@@ -97,8 +97,13 @@ export class GridExportService {
     //-----------------------
     getExportableColumns(gridModel, includeHiddenColumns) {
         return gridModel
-            .getLeafColumns({excludeHidden: !includeHiddenColumns})
-            .filter(col => !col.excludeFromExport);
+            .getLeafColumns()
+            .filter(col => {
+                return (
+                    !col.excludeFromExport &&
+                    (includeHiddenColumns || gridModel.isColumnVisible(col.colId))
+                );
+            });
     }
 
     getColumnMetadata(columns) {


### PR DESCRIPTION
+ Use in grid export + storeFilterField integrations, to reliably query for visible cols only when required.
+ Some smaller doc comment and syntax updates for clarity
+ Fixes #935