### PR TITLE
delete minWidth/Height and width/height from layoutProps if collapsed…

### DIFF
--- a/desktop/cmp/panel/Panel.js
+++ b/desktop/cmp/panel/Panel.js
@@ -93,8 +93,14 @@ export class Panel extends Component {
             resizable = false,
             collapsible = false,
             collapsed = false,
-            collapsedRenderMode = null
+            collapsedRenderMode = null,
+            vertical = false
         } = model || {};
+
+        if (collapsed) {
+            delete layoutProps[`min${vertical ? 'Height' : 'Width'}`];
+            delete layoutProps[vertical ? 'height' : 'width'];
+        }
 
         let coreContents = null;
         if (!collapsed || collapsedRenderMode == 'always' || (collapsedRenderMode == 'lazy' && this.wasDisplayed)) {


### PR DESCRIPTION
… (fixes #912)

should be viewed with corresponding toolbox branch: https://github.com/exhi/toolbox/tree/resize-panel-912

Do we want want to go further and:
1. prevent drag to smaller than a minWidth?
or 
2. warn if the 'defaultSize' is smaller than minWidth?
