### PR TITLE
Force Users to opt-out of stable ids on Records

### DIFF
--- a/admin/tabs/general/ehcache/EhCacheModel.js
+++ b/admin/tabs/general/ehcache/EhCacheModel.js
@@ -25,7 +25,8 @@ export class EhCacheModel {
         enableExport: true,
         store: new UrlStore({
             url: 'ehCacheAdmin/listCaches',
-            fields: ['name', 'heapSize', 'entries', 'status']
+            fields: ['name', 'heapSize', 'entries', 'status'],
+            idSpec: 'name'
         }),
         sortBy: 'name',
         columns: [

--- a/admin/tabs/general/services/ServiceModel.js
+++ b/admin/tabs/general/services/ServiceModel.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2018 Extremely Heavy Industries Inc.
  */
-import {XH, HoistModel} from '@xh/hoist/core';
+import {XH, HoistModel, managed} from '@xh/hoist/core';
 import {UrlStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {lowerFirst} from 'lodash';
@@ -13,8 +13,10 @@ import {PendingTaskModel} from '@xh/hoist/utils/async';
 @HoistModel
 export class ServiceModel {
 
+    @managed
     loadModel = new PendingTaskModel();
 
+    @managed
     gridModel = new GridModel({
         enableExport: true,
         store: new UrlStore({
@@ -57,9 +59,5 @@ export class ServiceModel {
     processRawData(r) {
         r.provider = r.name && r.name.startsWith('hoistCore') ? 'Hoist' : 'App';
         r.displayName = lowerFirst(r.name.replace('hoistCore', ''));
-    }
-
-    destroy() {
-        XH.safeDestroy(this.gridModel);
     }
 }

--- a/admin/tabs/general/services/ServiceModel.js
+++ b/admin/tabs/general/services/ServiceModel.js
@@ -20,7 +20,8 @@ export class ServiceModel {
         store: new UrlStore({
             url: 'serviceAdmin/listServices',
             processRawData: this.processRawData,
-            fields: ['provider', 'name', 'displayName']
+            fields: ['provider', 'name', 'displayName'],
+            idSpec: XH.genId
         }),
         selModel: 'multiple',
         sortBy: 'displayName',

--- a/admin/tabs/logging/viewer/LogViewerModel.js
+++ b/admin/tabs/logging/viewer/LogViewerModel.js
@@ -35,6 +35,7 @@ export class LogViewerModel {
         enableExport: true,
         store: new UrlStore({
             url: 'logViewerAdmin/listFiles',
+            idSpec: 'filename',
             dataRoot: 'files',
             fields: ['filename']
         }),

--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -9,7 +9,7 @@ import {XH} from '@xh/hoist/core';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {throwIf} from '@xh/hoist/utils/js';
 import {observable, action} from '@xh/hoist/mobx';
-import {isString, isUndefined} from 'lodash';
+import {isString, isNil} from 'lodash';
 
 import {RecordSet} from './impl/RecordSet';
 import {Record} from './Record';
@@ -151,7 +151,7 @@ export class LocalStore extends BaseStore {
 
             raw.id = idGen(raw);
             throwIf(
-                isUndefined(raw.id),
+                isNil(raw.id),
                 'Cannot load record without a unique id.  Provide a unique id on each raw record using the ' +
                 '`idSpec` property of this store.'
             );

--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -35,11 +35,11 @@ export class LocalStore extends BaseStore {
      * @param {Object} c - LocalStore configuration.
      * @param {function} [c.processRawData] - Function to run on data
      *      presented to loadData() before creating records.
-     * @param {[function|string]} [c.idSpec] - specification of how to identify an immutable unique
-     *      id for each record.  May be either a property (default is 'id') or a function to create the unique id
-     *      from the record.  If you cannot identify a unique id, you may set this argument to `XH.genId`
-     *      to have a unique id  generated on the fly for each record.  Note that in this case, grids and other
-     *      components bound to this store will not be able to maintain state for records across data reloading.
+     * @param {(function|string)} [c.idSpec] - specification for selecting or producing an immutable
+     *      unique id for each record. May be either a property (default is 'id') or a function to
+     *      create an id from a record. If there is no natural id to select/generate, you can use
+     *      `XH.genId` to generate a unique id on the fly. NOTE that in this case, grids and other
+     *      components bound to this store will not be able to maintain record state across reloads.
      * @param {function} [c.filter] - Filter function to be run.
      * @param {...*} [c.baseStoreArgs] - Additional properties to pass to BaseStore.
      */
@@ -49,7 +49,6 @@ export class LocalStore extends BaseStore {
             filter = null,
             idSpec = 'id',
             ...baseStoreArgs
-
         }) {
         super(baseStoreArgs);
         this.setFilter(filter);
@@ -152,8 +151,7 @@ export class LocalStore extends BaseStore {
             raw.id = idGen(raw);
             throwIf(
                 isNil(raw.id),
-                'Cannot load record without a unique id.  Provide a unique id on each raw record using the ' +
-                '`idSpec` property of this store.'
+                "Cannot load record with a null/undefined ID. Use the 'LocalStore.idSpec' config to resolve a unique ID for each record."
             );
 
             const rec = new Record({raw, parent, fields: this.fields});

--- a/data/impl/RecordSet.js
+++ b/data/impl/RecordSet.js
@@ -23,8 +23,8 @@ export class RecordSet {
     map;          // map of all records, by id
 
     /**
-     * @param {Record[]} rootRecords -  ordered list of root records to be included.
-     * This array will be used and modified by this object and should not be re-used.
+     * @param {Record[]} rootRecords -  ordered list of root records to be included. This array
+     *      will be used and modified by this object and should not be re-used.
      */
     constructor(rootRecords) {
         this.roots = rootRecords;
@@ -47,9 +47,7 @@ export class RecordSet {
     /**
      * Return a filtered version of this recordset.
      *
-     * @param {function} filter. If null, this method will return
-     *      the recordset itself.
-     *
+     * @param {function} filter. If null, this method will return the recordset itself.
      * @return {RecordSet}
      */
     applyFilter(filter) {
@@ -62,8 +60,7 @@ export class RecordSet {
      * Return a version of this recordset with a child removed.
      *
      * @param {Record} record to be removed.
-     *
-     * @return {Record}
+     * @return {RecordSet}
      */
     removeRecord(record) {
         return this.applyFilter(r => r.id !== record.id);
@@ -71,10 +68,10 @@ export class RecordSet {
 
     /**
      * Return a version of this recordset with a child added.
+     * NOTE: Currently adding a record at the root is the only supported operation.
      *
-     * NOTE:  Currently only adding a record at the root is the supported
-     *
-     * @param {Record} record
+     * @param {Record} record to be added.
+     * @return {RecordSet}
      */
     addRecord(record) {
         return new RecordSet([...this.roots, record]);
@@ -82,10 +79,11 @@ export class RecordSet {
 
     /**
      * Return a version of this recordset with a record replaced.
+     * NOTE: Currently replacing a record at the root is the only supported operation.
      *
-     * NOTE:  Currently only replacing a record at the root is supported
-     *
-     * @param {Record} record
+     * @param {Record} oldRecord
+     * @param {Record} newRecord
+     * @return {RecordSet}
      */
     updateRecord(oldRecord, newRecord) {
         const newRoots = clone(this.roots),

--- a/data/impl/RecordSet.js
+++ b/data/impl/RecordSet.js
@@ -30,11 +30,11 @@ export class RecordSet {
         this.roots = rootRecords;
 
         const {list, map} = this.gatherAllRecords(rootRecords);
-        this.list = (list.size == map.size ? rootRecords : list);  // Avoid holding two copies of same list.
+        this.list = (list.length == map.size ? rootRecords : list);  // Avoid holding two copies of same list.
         this.map = map;
 
         throwIf(
-            list.length > map.length,
+            list.length > map.size,
             'Store records cannot contain non-unique IDs.'
         );
     }


### PR DESCRIPTION
This fixes https://github.com/exhi/hoist-react/issues/844

Motivation was that a client was recently hit very hard by these auto-generated ids.  auto-refreshing grid with tens of thousands of rows was in production for weeks without ids, causing performance problems and memory issues.

Also, client noted that agGrid itself warns about missing ids, so we were actually papering over that warning by silently creating these ids for users.