### PR TITLE
Form field sizing redux

### DIFF
--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -204,11 +204,6 @@ export class FormField extends Component {
         );
     }
 
-    get hasSize() {
-        const {width, height, flex} = this.getLayoutProps();
-        return width || height || flex;
-    }
-
     get childIsSizeable() {
         const child = this.props.children;
         return child && child.type.hasLayoutSupport;
@@ -225,7 +220,6 @@ export class FormField extends Component {
 
     prepareChild({displayNotValid, leftErrorIcon, idAttr, errors, minimal, readonly}) {
         const {fieldModel} = this,
-            layoutProps = this.getLayoutProps(),
             item = this.props.children,
             {propTypes} = item.type;
 
@@ -236,16 +230,16 @@ export class FormField extends Component {
             id: idAttr
         };
 
-        // If FormField is sized and item doesn't specify its own dimensions,
-        // the item should fill the available size of the FormField.
+        // If a sizeable child input doesn't specify its own dimensions,
+        // the input should fill the available size of the FormField.
         // Note: We explicitly set width / height to null to override defaults.
-        if (this.hasSize && this.childIsSizeable) {
+        if (this.childIsSizeable) {
             if (isUndefined(item.props.width) && isUndefined(item.props.flex)) {
                 overrides.width = null;
                 overrides.flex = 1;
             }
 
-            if (isUndefined(item.props.height) && layoutProps.height) {
+            if (isUndefined(item.props.height)) {
                 overrides.height = null;
             }
         }

--- a/desktop/cmp/form/FormField.scss
+++ b/desktop/cmp/form/FormField.scss
@@ -23,7 +23,7 @@
       }
     }
 
-    & > .bp3-popover-wrapper:not(.xh-form-field-error-msg) {
+    .bp3-popover-wrapper:not(.xh-form-field-error-msg) {
       display: flex;
       flex: 1;
 

--- a/desktop/cmp/form/FormField.scss
+++ b/desktop/cmp/form/FormField.scss
@@ -15,7 +15,7 @@
     align-items: stretch;
 
     .xh-input {
-      & > .bp3-input-group {
+      .bp3-input-group {
         width: 100%;
       }
       &.bp3-popover-target, .bp3-popover-target {
@@ -23,12 +23,13 @@
       }
     }
 
-    & > .bp3-popover-wrapper {
+    & > .bp3-popover-wrapper:not(.xh-form-field-error-msg) {
+      display: flex;
       flex: 1;
 
       & > .bp3-popover-target {
-        flex: 1;
         display: flex;
+        flex: 1;
       }
     }
   }


### PR DESCRIPTION
+ Simplify conditions surrounding FormField sizing - HoistInputs within FormField always fill the FormField (unless sized themselves).
+ Fix CSS target to fill HoistInput within FormField

See toolbox branch: https://github.com/exhi/toolbox/pull/153