### PR TITLE
Hoist Dialog component

### DIFF
--- a/desktop/cmp/dialog/Dialog.js
+++ b/desktop/cmp/dialog/Dialog.js
@@ -1,0 +1,76 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+import {isArray, omit} from 'lodash';
+import PT from 'prop-types';
+import {Component} from 'react';
+
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
+import {dialog as bpDialog, dialogBody} from '@xh/hoist/kit/blueprint';
+import { toolbar } from '@xh/hoist/desktop/cmp/toolbar';
+
+import { DialogModel } from './DialogModel';
+
+
+/**
+ * A wrapper of Blueprint's Dialog component, with:
+ *  transition animations turned off by default
+ */
+@HoistComponent
+export class Dialog extends Component {
+
+    static modelClass = DialogModel;
+
+    static propTypes = {
+
+        /** Primary component model instance. */
+        model: PT.oneOfType([PT.instanceOf(DialogModel), PT.object]),
+
+        /** Primary component model instance. */
+        buttonBar: PT.oneOfType([PT.instanceOf(toolbar), PT.array])
+    };
+
+    baseClassName = 'xh-dialog';
+    
+    render() {
+        const {props} = this,
+            {className, children, model, buttonBar, ...rest} = this.getOverwrittenProps(),
+            isAnimated = model.isAnimated;
+
+        return bpDialog({
+            className: this.getClassName(),
+            isOpen: model.isOpen,
+            onClose: (evt) => model.onClose(evt),
+            isCloseButtonShown: model.isCloseButtonShown,
+            canEscapeKeyClose: model.canEscapeKeyClose,
+            transitionDuration: isAnimated ? props.transitionDuration : 0,
+            transitionName: isAnimated ? props.transitionName : 'none',
+
+            items: [
+                dialogBody(children),
+                this.getButtonBar(buttonBar)
+            ],
+            ...rest
+        });
+    }
+
+    animationKeys = ['transitionDuration', 'transitionName'];
+    closeKeys = ['isCloseButtonShown', 'canEscapeKeyClose', 'onClose'];
+    getOverwrittenProps() {
+        return omit(this.props, this.animationKeys, 'isOpen', this.closeKeys);
+    }
+
+    getButtonBar(buttonBar) {
+        if (isArray(buttonBar)) {
+            return toolbar(buttonBar);
+        } else {
+            return buttonBar;
+        }
+    }
+}
+export const dialog = elemFactory(Dialog);
+
+

--- a/desktop/cmp/dialog/DialogModel.js
+++ b/desktop/cmp/dialog/DialogModel.js
@@ -1,0 +1,67 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+import {HoistModel} from '@xh/hoist/core';
+import {observable, action} from '@xh/hoist/mobx';
+
+/**
+ * DialogModel supports configuration for modal dialog.
+ */
+@HoistModel
+export class DialogModel {
+
+    //-----------------------
+    // Immutable Properties
+    //-----------------------
+    isAnimated;
+    isCloseButtonShown;
+    canEscapeKeyClose;
+    onClose;
+
+
+    //---------------------
+    // Observable State
+    //---------------------
+    /** Is the Dialog open? */
+    @observable isOpen;
+
+
+    /**
+     * @param {Object} config
+     * @param {boolean} [config.isAnimated] - True to use css transition animations when showing/hiding dialog.
+     * @param {boolean} [config.isOpen] - Is model open or closed?
+     */
+    constructor({
+        isAnimated = false,
+        isCloseButtonShown = true,
+        canEscapeKeyClose = true,
+        onClose = this.close,
+        isOpen = false
+    } = {}) {
+        // Set immutables
+        this.isAnimated = isAnimated;
+        this.isCloseButtonShown = isCloseButtonShown;
+        this.canEscapeKeyClose = canEscapeKeyClose;
+        this.onClose = onClose;
+
+        // Set observable state
+        this.isOpen = isOpen;
+    }
+
+    //----------------------
+    // Actions
+    //----------------------
+    @action
+    close(evt) {
+        this.isOpen = false;
+    }
+
+    @action
+    open() {
+        this.isOpen = true;
+    }
+}

--- a/desktop/cmp/dialog/index.js
+++ b/desktop/cmp/dialog/index.js
@@ -1,0 +1,9 @@
+/*
+ * This file belongs to Hoist, an application development toolkit
+ * developed by Extremely Heavy Industries (www.xh.io | info@xh.io)
+ *
+ * Copyright © 2018 Extremely Heavy Industries Inc.
+ */
+
+export * from './Dialog';
+export * from './DialogModel';

--- a/desktop/cmp/mask/Mask.js
+++ b/desktop/cmp/mask/Mask.js
@@ -32,6 +32,9 @@ export class Mask extends Component {
         /** True to display mask. */
         isDisplayed: PT.bool,
 
+        /** True to use css transition animations when showing mask. */
+        isAnimated: PT.bool,
+
         /** Optional text to be displayed. */
         message: PT.string,
 
@@ -50,7 +53,8 @@ export class Mask extends Component {
     render() {
         const {props} = this,
             {model} = props,
-            isDisplayed = withDefault(props.isDisplayed, model && model.isPending, false);
+            isDisplayed = withDefault(props.isDisplayed, model && model.isPending, false),
+            isAnimated = withDefault(props.isAnimated, false);
 
         if (!isDisplayed) return null;
 
@@ -66,6 +70,7 @@ export class Mask extends Component {
             canEscapeKeyClose: false,
             usePortal: !inline,
             enforceFocus: !inline,
+            transitionName: isAnimated ? undefined : 'none',
             item: vbox({
                 className: 'xh-mask-body',
                 onClick,


### PR DESCRIPTION
This noAnimations branch has new code that turns off animations by default on mask and the new dialog component.

the new Dialog component wraps the BlueprintJS dialog, and is WIP.

This PR goes with toolbox PR: [#157](https://github.com/exhi/toolbox/pull/157)
and with toolbox branch [noAnimations](https://github.com/exhi/toolbox/tree/noAnimations).