### PR TITLE
Text Input Clear Icon

### DIFF
--- a/cmp/input/HoistInput.js
+++ b/cmp/input/HoistInput.js
@@ -84,8 +84,8 @@ export class HoistInput extends Component {
         value: PT.any
     };
 
-    @observable hasFocus;
-    @observable internalValue;
+    @observable hasFocus = false;
+    @observable internalValue = null;
 
     constructor(props) {
         super(props);

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -13,7 +13,6 @@ import {HoistInput} from '@xh/hoist/cmp/input';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {withDefault} from '@xh/hoist/utils/js';
-import {isString} from 'lodash';
 
 /**
  * A single-line text input with additional support for embedded icons/elements.
@@ -84,6 +83,8 @@ export class TextInput extends HoistInput {
         const props = this.getNonLayoutProps(),
             {width, flex, ...layoutProps} = this.getLayoutProps();
 
+        const isClearable = (this.internalValue !== null);
+
         return div({
             item: inputGroup({
                 value: this.renderValue || '',
@@ -93,7 +94,7 @@ export class TextInput extends HoistInput {
                 disabled: props.disabled,
                 leftIcon: props.leftIcon,
                 placeholder: props.placeholder,
-                rightElement: props.rightElement || (props.enableClear && isString(this.internalValue) ? this.renderClearIcon() : null),
+                rightElement: props.rightElement || (props.enableClear && isClearable ? this.renderClearButton() : null),
                 round: withDefault(props.round, false),
                 spellCheck: withDefault(props.spellCheck, false),
                 tabIndex: props.tabIndex,
@@ -121,7 +122,7 @@ export class TextInput extends HoistInput {
         });
     }
 
-    renderClearIcon() {
+    renderClearButton() {
         return button({
             icon: Icon.cross(),
             minimal: true,
@@ -130,10 +131,6 @@ export class TextInput extends HoistInput {
                 this.doCommit();
             }
         });
-    }
-
-    toExternal(val) {
-        return val === '' ? null : val;
     }
 
     onChange = (ev) => {

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -13,6 +13,7 @@ import {HoistInput} from '@xh/hoist/cmp/input';
 import {button} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {withDefault} from '@xh/hoist/utils/js';
+import {isString} from 'lodash';
 
 /**
  * A single-line text input with additional support for embedded icons/elements.
@@ -92,7 +93,7 @@ export class TextInput extends HoistInput {
                 disabled: props.disabled,
                 leftIcon: props.leftIcon,
                 placeholder: props.placeholder,
-                rightElement: props.rightElement || (props.enableClear ? this.renderClearIcon() : null),
+                rightElement: props.rightElement || (props.enableClear && isString(this.internalValue) ? this.renderClearIcon() : null),
                 round: withDefault(props.round, false),
                 spellCheck: withDefault(props.spellCheck, false),
                 tabIndex: props.tabIndex,
@@ -129,6 +130,10 @@ export class TextInput extends HoistInput {
                 this.doCommit();
             }
         });
+    }
+
+    toExternal(val) {
+        return val === '' ? null : val;
     }
 
     onChange = (ev) => {


### PR DESCRIPTION
This changes behavior to: 
- Icon not displayed on component mount (assuming no initialValue)
- Clear Icon is displayed as soon as text entered
- From that point, the icon display status mirrors the input's committed value. (note, textinput now converts empty string to null onCommit)