### PR TITLE
Default JsonInput height

### DIFF
--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -6,7 +6,7 @@
  */
 import React, {Component} from 'react';
 import PT from 'prop-types';
-import {isArray, isUndefined, isDate, isFinite, isBoolean} from 'lodash';
+import {isArray, isUndefined, isDate, isFinite, isBoolean, kebabCase} from 'lodash';
 
 import {elemFactory, HoistComponent, LayoutSupport, StableIdSupport} from '@xh/hoist/core';
 import {tooltip} from '@xh/hoist/kit/blueprint';
@@ -128,7 +128,7 @@ export class FormField extends Component {
             labelWidth = this.getDefaultedProp('labelWidth', null);
 
         // Styles
-        const classes = [];
+        const classes = [this.childCssName];
         if (isRequired) classes.push('xh-form-field-required');
         if (inline) classes.push('xh-form-field-inline');
         if (minimal) classes.push('xh-form-field-minimal');
@@ -207,6 +207,11 @@ export class FormField extends Component {
     get childIsSizeable() {
         const child = this.props.children;
         return child && child.type.hasLayoutSupport;
+    }
+
+    get childCssName() {
+        const child = this.props.children;
+        return child ? `xh-form-field-${kebabCase(child.type.name)}` : null;
     }
 
     getDefaultedProp(name, defaultVal) {

--- a/desktop/cmp/form/FormField.scss
+++ b/desktop/cmp/form/FormField.scss
@@ -27,7 +27,8 @@
       display: flex;
       flex: 1;
 
-      & > .bp3-popover-target {
+      & > .bp3-popover-target,
+      & > .bp3-popover-target > .bp3-control-group {
         display: flex;
         flex: 1;
       }
@@ -50,6 +51,10 @@
   &.xh-form-field-inline {
     flex-direction: row;
     align-items: baseline;
+
+    &.xh-form-field-json-input {
+      align-items: start;
+    }
 
     .xh-form-field-label {
       padding: 0 var(--xh-pad-half-px) 0 0;

--- a/desktop/cmp/input/JsonInput.scss
+++ b/desktop/cmp/input/JsonInput.scss
@@ -16,10 +16,8 @@
     }
   }
 
-  // TODO - understanding sizing spec / requirements for component vs. generated CodeMirror.
-  // See also layout props on the component itself.
-  // https://github.com/exhi/hoist-react/issues/327
   .CodeMirror {
+    height: 100px;
     flex: 1;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
+ Tweak CSS height for an 'unsized' json input to match the code default. Fixes #997.
+ Added CSS class to FormField indicating the type of child input.
+ Fixed label alignment in inline mode.