### PR TITLE
Suppress browser context menu on ag-grid context menu click

### DIFF
--- a/core/XH.js
+++ b/core/XH.js
@@ -441,6 +441,8 @@ class XHClass {
 
         // Add xh-app class to body element to power Hoist CSS selectors
         document.body.classList.add('xh-app');
+        document.addEventListener('contextmenu', this.handleContextMenuRightClick);
+
 
         try {
             await this.installServicesAsync(FetchService, LocalStorageService);
@@ -601,6 +603,11 @@ class XHClass {
                 }
             }
         });
+    }
+
+    handleContextMenuRightClick = (ev) => {
+        if (ev.path.find(it => it.className && isString(it.className) &&
+            it.className.includes('ag-menu-list'))) ev.preventDefault()
     }
 }
 export const XH = window.XH = new XHClass();


### PR DESCRIPTION
For #917 . Issue is caused by the way we override the grid's `popupParent` [prop](https://www.ag-grid.com/javascript-grid-context-menu/). That override can't be removed without causing other display bugs.

Ag API is pretty limited w.r.t. context menu customization, and I was only able to change the behavior with this ugly and maybe unnecessary change.