### PR TITLE
Use consistent process when creating Records

### DIFF
--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -133,9 +133,6 @@ export class LocalStore extends BaseStore {
         this.rebuildFiltered();
     }
 
-    //------------------------
-    // Private Implementation
-    //------------------------
     createRecords(rawData, parent = null) {
         return rawData.map(raw => this.createRecord(raw, parent));
     }
@@ -157,6 +154,9 @@ export class LocalStore extends BaseStore {
         return rec;
     }
 
+    //------------------------
+    // Private Implementation
+    //------------------------
     @action
     rebuildFiltered() {
         this._filtered = this._all.applyFilter(this.filter);

--- a/data/LocalStore.js
+++ b/data/LocalStore.js
@@ -137,22 +137,24 @@ export class LocalStore extends BaseStore {
     // Private Implementation
     //------------------------
     createRecords(rawData, parent = null) {
+        return rawData.map(raw => this.createRecord(raw, parent));
+    }
+
+    createRecord(raw, parent = null) {
         const {idSpec} = this;
         const idGen = isString(idSpec) ? r => r[idSpec] : idSpec;
 
-        return rawData.map(raw => {
-            if (this.processRawData) this.processRawData(raw);
+        if (this.processRawData) this.processRawData(raw);
 
-            raw.id = idGen(raw);
-            throwIf(
-                isNil(raw.id),
-                "Cannot load record with a null/undefined ID. Use the 'LocalStore.idSpec' config to resolve a unique ID for each record."
-            );
+        raw.id = idGen(raw);
+        throwIf(
+            isNil(raw.id),
+            "Cannot load record with a null/undefined ID. Use the 'LocalStore.idSpec' config to resolve a unique ID for each record."
+        );
 
-            const rec = new Record({raw, parent, fields: this.fields});
-            rec.children = raw.children ? this.createRecords(raw.children, rec) : [];
-            return rec;
-        });
+        const rec = new Record({raw, parent, fields: this.fields});
+        rec.children = raw.children ? this.createRecords(raw.children, rec) : [];
+        return rec;
     }
 
     @action

--- a/desktop/cmp/rest/data/RestStore.js
+++ b/desktop/cmp/rest/data/RestStore.js
@@ -6,7 +6,7 @@
  */
 
 import {XH} from '@xh/hoist/core';
-import {UrlStore, Record} from '@xh/hoist/data';
+import {UrlStore} from '@xh/hoist/data';
 import {pickBy, filter} from 'lodash';
 
 import {RestField} from './RestField';
@@ -78,7 +78,7 @@ export class RestStore extends UrlStore {
 
         const fetchMethod = isAdd ? 'postJson' : 'putJson',
             response = await XH.fetchService[fetchMethod]({url, body: {data}}),
-            newRec = new Record({fields: this.fields, raw: response.data});
+            newRec = this.createRecord(response.data);
 
         if (isAdd) {
             this.addRecordInternal(newRec);


### PR DESCRIPTION
Fixes #1010 

Minor refactor to allow creating a single Record, and use that method in RestStore after the save operation. 