### PR TITLE
GridModel.store config accepts a plain object, creates LocalStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v21.0.0-SNAPSHOT (under development)
+
+### ⚙️ Technical
+
+* The `GridModel.store` config now accepts a plain object and will internally create a `LocalStore`.
+
 ## v20.0.1 - 2019-03-08
 
 ### 🐞 Bug Fixes

--- a/admin/tabs/activity/clienterrors/ClientErrorModel.js
+++ b/admin/tabs/activity/clienterrors/ClientErrorModel.js
@@ -7,7 +7,6 @@
 import moment from 'moment';
 import {XH, HoistModel, managed, LoadSupport} from '@xh/hoist/core';
 import {action, observable, comparer} from '@xh/hoist/mobx';
-import {LocalStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtDate, fmtSpan} from '@xh/hoist/format';
 import {boolCheckCol, compactDateCol} from '@xh/hoist/cmp/grid';
@@ -30,12 +29,12 @@ export class ClientErrorModel {
         enableColChooser: true,
         enableExport: true,
         exportOptions: {filename: () => `Client Errors ${fmtDate(this.startDate)} to ${fmtDate(this.endDate)}`},
-        store: new LocalStore({
+        store: {
             fields: [
                 'username', 'error', 'msg', 'userAlerted', 'browser', 'device',
                 'appVersion', 'appEnvironment', 'dateCreated', 'userAgent'
             ]
-        }),
+        },
         sortBy: {colId: 'dateCreated', sort: 'desc'},
         columns: [
             {field: 'dateCreated', ...compactDateCol, width: 140},

--- a/admin/tabs/activity/tracking/ActivityGridModel.js
+++ b/admin/tabs/activity/tracking/ActivityGridModel.js
@@ -7,7 +7,6 @@
 import moment from 'moment';
 import {XH, HoistModel, managed, LoadSupport} from '@xh/hoist/core';
 import {action, observable, comparer} from '@xh/hoist/mobx';
-import {LocalStore} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {fmtDate, numberRenderer} from '@xh/hoist/format';
 import {dateTimeCol} from '@xh/hoist/cmp/grid';
@@ -33,13 +32,13 @@ export class ActivityGridModel {
         enableColChooser: true,
         enableExport: true,
         exportOptions: {filename: () => `Activity ${fmtDate(this.startDate)} to ${fmtDate(this.endDate)}`},
-        store: new LocalStore({
+        store: {
             fields: [
                 'severity', 'dateCreated', 'username', 'msg', 'category',
                 'device', 'browser', 'data', 'impersonating', 'elapsed',
                 'userAgent'
             ]
-        }),
+        },
         sortBy: {colId: 'dateCreated', sort: 'desc'},
         columns: [
             {field: 'severity', width: 100},

--- a/admin/tabs/general/configs/differ/ConfigDifferModel.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferModel.js
@@ -10,7 +10,6 @@ import {action, observable} from '@xh/hoist/mobx';
 import {cloneDeep, isEqual, remove, trimEnd} from 'lodash';
 import {pluralize} from '@xh/hoist/utils/js';
 import {XH, HoistModel, managed} from '@xh/hoist/core';
-import {LocalStore} from '@xh/hoist/data';
 import {p} from '@xh/hoist/cmp/layout';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {StoreContextMenu} from '@xh/hoist/desktop/cmp/contextmenu';
@@ -52,14 +51,14 @@ export class ConfigDifferModel  {
 
         this.gridModel = new GridModel({
             enableExport: true,
-            store: new LocalStore({
+            store: {
                 fields: [
                     'name', 'status', 'localValue', 'remoteValue'
                 ],
                 idSpec: 'name',
                 name: 'differ',
                 filter: (it) => it.status !== 'Identical'
-            }),
+            },
             selModel: 'multiple',
             columns: [
                 {field: 'name', width: 200},

--- a/admin/tabs/general/users/UserModel.js
+++ b/admin/tabs/general/users/UserModel.js
@@ -6,7 +6,6 @@
  */
 
 import {HoistModel, XH, LoadSupport, managed} from '@xh/hoist/core';
-import {LocalStore} from '@xh/hoist/data';
 import {allSettled} from '@xh/hoist/promise';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {boolCheckCol} from '@xh/hoist/cmp/grid';
@@ -26,10 +25,10 @@ export class UserModel {
         stateModel: 'xhUserGrid',
         enableColChooser: true,
         enableExport: true,
-        store: new LocalStore({
+        store: {
             fields: ['username', 'email', 'displayName', 'active', 'roles'],
             idSpec: 'username'
-        }),
+        },
         sortBy: 'username',
         columns: [
             {field: 'username', ...usernameCol},

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -6,7 +6,6 @@
  */
 import {HoistModel} from '@xh/hoist/core';
 import {Icon} from '@xh/hoist/icon';
-import {LocalStore} from '@xh/hoist/data';
 import {action, bindable, observable} from '@xh/hoist/mobx';
 import {fileExtCol, GridModel} from '@xh/hoist/cmp/grid';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
@@ -24,10 +23,10 @@ export class FileChooserModel {
     lastRejectedCount;
 
     gridModel = new GridModel({
-        store: new LocalStore({
+        store: {
             fields: ['name', 'extension', 'size'],
             idSpec: 'name'
-        }),
+        },
         columns: [
             {
                 field: 'extension',

--- a/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
+++ b/desktop/cmp/leftrightchooser/LeftRightChooserModel.js
@@ -6,7 +6,6 @@
  */
 import {HoistModel, XH, managed} from '@xh/hoist/core';
 import {GridModel} from '@xh/hoist/cmp/grid';
-import {LocalStore} from '@xh/hoist/data';
 import {computed} from '@xh/hoist/mobx';
 import {convertIconToSvg, Icon} from '@xh/hoist/icon';
 import {isNil} from 'lodash';
@@ -122,14 +121,14 @@ export class LeftRightChooserModel {
             };
 
         this.leftModel = new GridModel({
-            store: new LocalStore({fields}),
+            store: {fields},
             selModel: 'multiple',
             sortBy: leftSorted ? 'text' : null,
             columns: [leftTextCol, groupCol]
         });
 
         this.rightModel = new GridModel({
-            store: new LocalStore({fields}),
+            store: {fields},
             selModel: 'multiple',
             sortBy: rightSorted ? 'text' : null,
             columns: [rightTextCol, groupCol]


### PR DESCRIPTION
+ Clean up instances where we were creating a new LocalStore inline
+ Mark created store as managed within GridModel. Note that stores do not yet actually implement destroy() but will when #1014 complete.
+ Fixes #1013 