### PR TITLE
DataViewModel - remove dupe references to GridModel properties

### DIFF
--- a/desktop/cmp/dataview/DataViewModel.js
+++ b/desktop/cmp/dataview/DataViewModel.js
@@ -5,11 +5,10 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 
-import {isPlainObject, defaults, isString, omit} from 'lodash';
 import {HoistModel, managed} from '@xh/hoist/core';
-import {StoreSelectionModel} from '@xh/hoist/data';
 import {GridModel} from '@xh/hoist/cmp/grid';
 import {throwIf} from '@xh/hoist/utils/js';
+import {omit} from 'lodash';
 
 /**
  * DataViewModel is a wrapper around GridModel, which shows sorted data in a single column,
@@ -20,19 +19,14 @@ import {throwIf} from '@xh/hoist/utils/js';
 @HoistModel
 export class DataViewModel {
 
-    // Immutable public properties
-    itemRenderer = null;
-    store = null;
-    selModel = null;
-    contextMenuFn = null;
-
     @managed
     gridModel;
 
     /**
      * @param {Object} c - DataViewModel configuration.
      * @param {Column~elementRendererFn} c.itemRenderer - function which returns a React component.
-     * @param {BaseStore} c.store - store containing the data to be displayed.
+     * @param {(BaseStore|Object)} c.store - a Store instance, or a config with which to create a
+     *      default LocalStore. The store is the source for the view's data.
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` from which to create.
      * @param {string} [c.emptyText] - text/HTML to display if view has no records.
@@ -45,15 +39,6 @@ export class DataViewModel {
         emptyText,
         contextMenuFn = null
     }) {
-
-        selModel = this.parseSelModel(selModel, store);
-
-        this.itemRenderer = itemRenderer;
-        this.store = store;
-        this.selModel = selModel;
-        this.emptyText = emptyText;
-        this.contextMenuFn = contextMenuFn;
-
         this.gridModel = new GridModel({
             store,
             selModel,
@@ -73,9 +58,17 @@ export class DataViewModel {
 
     }
 
+    get store() {
+        return this.gridModel.store;
+    }
+
+    get selModel() {
+        return this.gridModel.selModel;
+    }
+
     /**
      * Select the first row in the dataview.
-     * Note that dataview assumes store data is already sorted
+     * Note that dataview assumes store data is already sorted.
      */
     selectFirst() {
         const {store, selModel} = this,
@@ -86,7 +79,6 @@ export class DataViewModel {
 
     /**
      * Shortcut to the currently selected records (observable).
-     *
      * @see StoreSelectionModel.records
      */
     get selection() {
@@ -94,9 +86,7 @@ export class DataViewModel {
     }
 
     /**
-     * Shortcut to a single selected record (observable).
-     * This will be null if multiple records are selected.
-     *
+     * Shortcut to a single selected record (observable), or null if multiple records selected.
      * @see StoreSelectionModel.singleRecord
      */
     get selectedRecord() {
@@ -118,27 +108,6 @@ export class DataViewModel {
     //------------------------
     // Implementation
     //------------------------
-    parseSelModel(selModel, store) {
-        if (selModel instanceof StoreSelectionModel) {
-            return selModel;
-        }
-
-        if (isPlainObject(selModel)) {
-            return new StoreSelectionModel(defaults(selModel, {store}));
-        }
-
-        // Assume its just the mode...
-        let mode = 'single';
-        if (isString(selModel)) {
-            mode = selModel;
-        } else  if (selModel === null) {
-            mode = 'disabled';
-        }
-
-        return new StoreSelectionModel({mode, store});
-    }
-
-
     valueGetter = (params) => {
         const realData = omit(params.data.raw, 'id');
         return Object.values(realData).join('\r');


### PR DESCRIPTION
+ Did not see a need to save extra references to the ctor params, added getter for store and selModel.
+ Rely on GridModel to parse selModel and store configs, including recently added support for plain object store configs.