### PR TITLE
Remove 'delay' workaround to avoid focus blurring.

### DIFF
--- a/cmp/input/HoistInput.js
+++ b/cmp/input/HoistInput.js
@@ -12,7 +12,6 @@ import {FieldModel} from '@xh/hoist/cmp/form';
 import {throwIf} from '@xh/hoist/utils/js';
 import {observable, computed, action} from '@xh/hoist/mobx';
 import classNames from 'classnames';
-import {wait} from '@xh/hoist/promise';
 
 import './HoistInput.scss';
 

--- a/cmp/input/HoistInput.js
+++ b/cmp/input/HoistInput.js
@@ -218,14 +218,11 @@ export class HoistInput extends Component {
         this.hasFocus = false;
     }
 
-    onBlur = () => {
-        // Focus very frequently will be jumping internally from element to element *within* a control.
-        // This delay prevents extraneous 'flapping' of focus state at this level.
-        wait(200).then(() => {
-            if (!this.containsElement(document.activeElement)) {
-                this.noteBlurred();
-            }
-        });
+    onBlur = (e) => {
+        // Ignore focus jumping internally from *within* the control.
+        if (!this.containsElement(e.relatedTarget)) {
+            this.noteBlurred();
+        }
     }
 
     /**


### PR DESCRIPTION
This workaround was causing tricky problems for apps that were getting stale data during this interval.