### PR TITLE
Allow FormField labelWidth to override min width.

### DIFF
--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -6,7 +6,7 @@
  */
 import React, {Component} from 'react';
 import PT from 'prop-types';
-import {isArray, isUndefined, isDate, isFinite, isBoolean, kebabCase} from 'lodash';
+import {isArray, isUndefined, isDate, isFinite, isBoolean, isNil, kebabCase} from 'lodash';
 
 import {elemFactory, HoistComponent, LayoutSupport, StableIdSupport} from '@xh/hoist/core';
 import {tooltip} from '@xh/hoist/kit/blueprint';
@@ -146,7 +146,8 @@ export class FormField extends Component {
                     htmlFor: clickableLabel ? idAttr : null,
                     style: {
                         textAlign: labelAlign,
-                        width: labelWidth
+                        width: labelWidth,
+                        minWidth: isNil(labelWidth) ? 80 : 0
                     }
                 }),
                 div({

--- a/desktop/cmp/form/FormField.scss
+++ b/desktop/cmp/form/FormField.scss
@@ -58,7 +58,6 @@
 
     .xh-form-field-label {
       padding: 0 var(--xh-pad-half-px) 0 0;
-      min-width: 80px;
     }
   }
 


### PR DESCRIPTION
I moved the application of the min width out of the css and into JS, and only apply it if a specific labelWidth has not been provided. This maintains the current expected behaviour, while allowing labels narrower than 80px.

Another potential solution would be to remove the concept of a min width entirely - labels are either sized explicitly, or use their natural size. This may be a simpler API, but may potentially be a breaking change to any apps currently depending on the min width.