### PR TITLE
Updates to Grid style / visual config and CSS

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -83,12 +83,7 @@ export class Grid extends Component {
          * Callback to call when a cell is double clicked. Function will receive an event
          * with a data node, cell value, and column.
          */
-        onCellDoubleClicked: PT.func,
-
-        /**
-         * Show a colored row background on hover. Defaults to false.
-         */
-        showHover: PT.bool
+        onCellDoubleClicked: PT.func
     };
 
     static ROW_HEIGHT = 28;
@@ -124,8 +119,9 @@ export class Grid extends Component {
     }
 
     render() {
-        const {compact, treeMode} = this.model,
-            {agOptions, showHover, onKeyDown} = this.props,
+        const {model, props} = this,
+            {treeMode, compact, highlightOnHover, rowBorders, stripeRows} = model,
+            {agOptions, onKeyDown} = props,
             {isMobile} = XH,
             layoutProps = this.getLayoutProps();
 
@@ -144,9 +140,11 @@ export class Grid extends Component {
                 className: this.getClassName(
                     'ag-grid-holder',
                     XH.darkTheme ? 'ag-theme-balham-dark' : 'ag-theme-balham',
-                    compact ? 'xh-grid-compact' : 'xh-grid-standard',
-                    treeMode && this._isHierarchical ? 'xh-grid-hierarchical' : '',
-                    !isMobile && showHover ? 'xh-grid-show-hover' : ''
+                    treeMode && this._isHierarchical ? 'xh-grid--hierarchical' : 'xh-grid--flat',
+                    compact ? 'xh-grid--compact' : 'xh-grid--standard',
+                    rowBorders ? '' : 'xh-grid--no-row-borders',
+                    stripeRows ? '' : 'xh-grid--no-stripes',
+                    !isMobile && highlightOnHover ? 'xh-grid--highlight-on-hover' : ''
                 ),
                 onKeyDown: !isMobile ? onKeyDown : null
             }),

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -84,8 +84,16 @@ export class GridModel {
     @observable.ref sortBy = [];
     /** @member {string[]} */
     @observable groupBy = null;
+
     /** @member {boolean} */
     @observable compact = false;
+    /** @member {boolean} */
+    @observable highlightOnHover = false;
+    /** @member {boolean} */
+    @observable rowBorders = false;
+    /** @member {boolean} */
+    @observable stripeRows = true;
+
     /** @member {GridApi} */
     @observable.ref agApi = null;
     /** @member {ColumnApi} */
@@ -125,7 +133,10 @@ export class GridModel {
      * @param {(string|string[]|Object|Object[])} [c.sortBy] - colId(s) or sorter config(s) with
      *      colId and sort direction.
      * @param {(string|string[])} [c.groupBy] - Column ID(s) by which to do full-width row grouping.
-     * @param {boolean} [c.compact] - true to render the grid in compact mode.
+     * @param {boolean} [c.compact] - true to render with a smaller font size and tighter padding.
+     * @param {boolean} [c.highlightOnHover] - true to highlight the currently hovered row.
+     * @param {boolean} [c.rowBorders] - true to render row borders.
+     * @param {boolean} [c.stripeRows] - true (default) to use alternating backgrounds for rows.
      * @param {boolean} [c.enableColChooser] - true to setup support for column chooser UI and
      *      install a default context menu item to launch the chooser.
      * @param {boolean} [c.enableExport] - true to enable exporting this grid and
@@ -146,7 +157,12 @@ export class GridModel {
         emptyText = null,
         sortBy = [],
         groupBy = null,
+
         compact = false,
+        highlightOnHover = false,
+        rowBorders = false,
+        stripeRows = true,
+
         enableColChooser = false,
         enableExport = false,
         exportOptions = {},
@@ -169,7 +185,11 @@ export class GridModel {
 
         this.setGroupBy(groupBy);
         this.setSortBy(sortBy);
+
         this.setCompact(compact);
+        this.setHighlightOnHover(highlightOnHover);
+        this.setRowBorders(rowBorders);
+        this.setStripeRows(stripeRows);
 
         this.colChooserModel = enableColChooser ? this.createChooserModel() : null;
         this.selModel = this.parseSelModel(selModel);
@@ -313,11 +333,6 @@ export class GridModel {
         }
 
         this.sortBy = sorters;
-    }
-
-    @action
-    setCompact(compact) {
-        this.compact = compact;
     }
 
     /** Load the underlying store. */
@@ -478,6 +493,12 @@ export class GridModel {
     buildColumn(c) {
         return c.children ? new ColumnGroup(c, this) : new Column(c, this);
     }
+
+    // Misc setters for visual/style observables.
+    @action setCompact(compact)                     {this.compact = compact}
+    @action setHighlightOnHover(highlightOnHover)   {this.highlightOnHover = highlightOnHover}
+    @action setRowBorders(rowBorders)               {this.rowBorders = rowBorders}
+    @action setStripeRows(stripeRows)               {this.stripeRows = stripeRows}
 
 
     //-----------------------

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -9,7 +9,7 @@ import {Column, ColumnGroup} from '@xh/hoist/cmp/grid';
 import {BaseStore, LocalStore, StoreSelectionModel} from '@xh/hoist/data';
 import {ColChooserModel as DesktopColChooserModel, StoreContextMenu} from '@xh/hoist/dynamics/desktop';
 import {ColChooserModel as MobileColChooserModel} from '@xh/hoist/dynamics/mobile';
-import {action, observable} from '@xh/hoist/mobx';
+import {action, observable, bindable} from '@xh/hoist/mobx';
 import {throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
 import {
     castArray,
@@ -86,13 +86,13 @@ export class GridModel {
     @observable groupBy = null;
 
     /** @member {boolean} */
-    @observable compact = false;
+    @bindable compact = false;
     /** @member {boolean} */
-    @observable highlightOnHover = false;
+    @bindable highlightOnHover = false;
     /** @member {boolean} */
-    @observable rowBorders = false;
+    @bindable rowBorders = false;
     /** @member {boolean} */
-    @observable stripeRows = true;
+    @bindable stripeRows = true;
 
     /** @member {GridApi} */
     @observable.ref agApi = null;
@@ -186,10 +186,10 @@ export class GridModel {
         this.setGroupBy(groupBy);
         this.setSortBy(sortBy);
 
-        this.setCompact(compact);
-        this.setHighlightOnHover(highlightOnHover);
-        this.setRowBorders(rowBorders);
-        this.setStripeRows(stripeRows);
+        this.compact = compact;
+        this.highlightOnHover = highlightOnHover;
+        this.rowBorders = rowBorders;
+        this.stripeRows = stripeRows;
 
         this.colChooserModel = enableColChooser ? this.createChooserModel() : null;
         this.selModel = this.parseSelModel(selModel);
@@ -493,14 +493,7 @@ export class GridModel {
     buildColumn(c) {
         return c.children ? new ColumnGroup(c, this) : new Column(c, this);
     }
-
-    // Misc setters for visual/style observables.
-    @action setCompact(compact)                     {this.compact = compact}
-    @action setHighlightOnHover(highlightOnHover)   {this.highlightOnHover = highlightOnHover}
-    @action setRowBorders(rowBorders)               {this.rowBorders = rowBorders}
-    @action setStripeRows(stripeRows)               {this.stripeRows = stripeRows}
-
-
+    
     //-----------------------
     // Implementation
     //-----------------------

--- a/cmp/grid/ag-grid/styles.scss
+++ b/cmp/grid/ag-grid/styles.scss
@@ -66,8 +66,11 @@
   //------------------------
   .ag-row {
     background-color: var(--xh-grid-bg);
-    border-bottom-color: var(--xh-grid-border-color);
 
+    // Row borders.
+    border-color: var(--xh-grid-border-color);
+
+    // Zebra striping.
     &.ag-row-odd {
       background-color: var(--xh-grid-bg-odd);
     }
@@ -90,6 +93,20 @@
     }
   }
 
+  // Suppress row borders.
+  &--no-row-borders {
+    .ag-row {
+      border-color: transparent;
+    }
+  }
+
+  // Suppress zebra striping.
+  &--no-stripes {
+    .ag-row.ag-row-odd {
+      background-color: var(--xh-grid-bg);
+    }
+  }
+
 
   //------------------------
   // Core Cell Classes
@@ -107,7 +124,7 @@
   //------------------------
   // Trees and Grouping
   //------------------------
-  &.xh-grid-hierarchical {
+  &--hierarchical {
     // Generate indentations for tree grids with hierarchical data.
     // Based upon https://github.com/ag-grid/ag-grid/blob/master/packages/ag-grid-community/src/styles/ag-grid.scss#L1084
     $xh-tree-indent: 10px !default;
@@ -126,14 +143,40 @@
     }
   }
 
+  // Suppress default indenting when grid is in tree mode but no root records have children.
+  &--flat {
+    .ag-ltr .ag-row-group-leaf-indent {
+      margin-left: 0;
+    }
+  }
+
+
   // As of agGrid 20, the group row always reserve space for a grouping checkbox.
   // We remove this to tighten up the spacing.
   .ag-group-checkbox.ag-invisible {
     display: none;
   }
 
-  .ag-ltr .ag-row-group-leaf-indent {
-    margin-left: 0;
+
+  //------------------------
+  // Compact Mode
+  //------------------------
+  &--compact {
+    font-size: var(--xh-grid-compact-font-size-px);
+
+    .ag-cell-value {
+      line-height: var(--xh-grid-compact-line-height-px);
+    }
+
+    .ag-header {
+      font-size: var(--xh-grid-compact-font-size-px);
+    }
+
+    .ag-cell, .ag-header-cell, .ag-header-group-cell {
+      padding-left: var(--xh-grid-compact-cell-lr-pad-px);
+      padding-right: var(--xh-grid-compact-cell-lr-pad-px);
+    }
+
   }
 
 
@@ -145,12 +188,12 @@
     outline: 0 !important;
   }
 
-  &.xh-grid-show-hover .ag-row.ag-row-hover:not(.ag-row-group):not(.ag-row-selected) {
+  &--highlight-on-hover .ag-row.ag-row-hover:not(.ag-row-group):not(.ag-row-selected) {
     background-color: var(--xh-grid-bg-hover);
   }
 
   // Grouped rows appear slightly misaligned (standard mode only)
-  &.xh-grid-standard .ag-row.ag-row-group {
+  &--standard .ag-row.ag-row-group {
     padding-top: 2px;
   }
 
@@ -162,27 +205,6 @@
 
   // Disabling the "row loading" render overlay
   .ag-bl-overlay {display: none;}
-}
-
-
-//------------------------
-// Compact Mode
-//------------------------
-.xh-grid-compact {
-  font-size: var(--xh-grid-compact-font-size-px);
-
-  .ag-cell-value {
-    line-height: var(--xh-grid-compact-line-height-px);
-  }
-
-  .ag-header {
-    font-size: var(--xh-grid-compact-font-size-px);
-  }
-
-  .ag-cell, .ag-header-cell, .ag-header-group-cell {
-    padding-left: var(--xh-grid-compact-cell-lr-pad-px);
-    padding-right: var(--xh-grid-compact-cell-lr-pad-px);
-  }
 
 }
 

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -74,7 +74,7 @@ body {
   --xh-grid-bg-hover: var(--grid-bg-highlight, #{mc-trans('blue', '200', 0.8)});
   --xh-grid-bg-highlight: var(--grid-bg-highlight, var(--xh-bg-highlight));
   --xh-grid-bg-odd: var(--grid-bg-odd, #{mc('grey', '100')});
-  --xh-grid-border-color: var(--grid-border-color, var(--xh-border-color));
+  --xh-grid-border-color: var(--grid-border-color, #{mc('grey', '300')});
   --xh-grid-cell-focus-border-color: var(--grid-cell-focus-border-color, transparent);
   --xh-grid-cell-lr-pad: var(--grid-cell-lr-pad, 11);
   --xh-grid-cell-lr-pad-px: calc(var(--xh-grid-cell-lr-pad) * 1px);


### PR DESCRIPTION
+ Support rowBorders and stripeRows observables on GridModel.
+ Borders off by default, row striping remains on.
+ Move Grid.showHover prop -> GridModel.highlightOnHover.
+ Update grid variant CSS class names to BEM conventions.
+ Ensure Hoist border-color CSS var actually applies, then set to a lighter value.