### PR TITLE
GridModel option to show cell focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 
 ### 🎁 New Features
 
-* `GridModel` exposes two new configs `rowBorders` and `stripRows` to provide additional control
-  over grid styling, and the former `Grid` prop `showHover` has been renamed and also converted to a
-  `GridModel` config as `highlightOnHover`. Note that some grid-related CSS classes have also been
-  modified to better conform to the BEM approach used elsewhere.
+* `GridModel` exposes three new configs - `rowBorders`, `stripeRows`, and `showCellFocus` - to
+  provide additional control over grid styling, and the former `Grid` prop `showHover` has been
+  renamed and also converted to a `GridModel` config as `highlightOnHover`. Note that some
+  grid-related CSS classes have also been modified to better conform to the BEM approach used
+  elsewhere.
 
 ### 🐞 Bug Fixes
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -120,7 +120,7 @@ export class Grid extends Component {
 
     render() {
         const {model, props} = this,
-            {treeMode, compact, highlightOnHover, rowBorders, stripeRows} = model,
+            {treeMode, compact, highlightOnHover, rowBorders, stripeRows, showCellFocus} = model,
             {agOptions, onKeyDown} = props,
             {isMobile} = XH,
             layoutProps = this.getLayoutProps();
@@ -144,6 +144,7 @@ export class Grid extends Component {
                     compact ? 'xh-grid--compact' : 'xh-grid--standard',
                     rowBorders ? '' : 'xh-grid--no-row-borders',
                     stripeRows ? '' : 'xh-grid--no-stripes',
+                    showCellFocus ? 'xh-grid--show-cell-focus' : '',
                     !isMobile && highlightOnHover ? 'xh-grid--highlight-on-hover' : ''
                 ),
                 onKeyDown: !isMobile ? onKeyDown : null

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -86,13 +86,15 @@ export class GridModel {
     @observable groupBy = null;
 
     /** @member {boolean} */
-    @bindable compact = false;
+    @bindable compact;
     /** @member {boolean} */
-    @bindable highlightOnHover = false;
+    @bindable highlightOnHover;
     /** @member {boolean} */
-    @bindable rowBorders = false;
+    @bindable rowBorders;
     /** @member {boolean} */
-    @bindable stripeRows = true;
+    @bindable stripeRows;
+    /** @member {boolean} */
+    @bindable showCellFocus;
 
     /** @member {GridApi} */
     @observable.ref agApi = null;
@@ -137,6 +139,7 @@ export class GridModel {
      * @param {boolean} [c.highlightOnHover] - true to highlight the currently hovered row.
      * @param {boolean} [c.rowBorders] - true to render row borders.
      * @param {boolean} [c.stripeRows] - true (default) to use alternating backgrounds for rows.
+     * @param {boolean} [c.showCellFocus] - true to highlight the focused cell with a border.
      * @param {boolean} [c.enableColChooser] - true to setup support for column chooser UI and
      *      install a default context menu item to launch the chooser.
      * @param {boolean} [c.enableExport] - true to enable exporting this grid and
@@ -162,6 +165,7 @@ export class GridModel {
         highlightOnHover = false,
         rowBorders = false,
         stripeRows = true,
+        showCellFocus = false,
 
         enableColChooser = false,
         enableExport = false,
@@ -190,6 +194,7 @@ export class GridModel {
         this.highlightOnHover = highlightOnHover;
         this.rowBorders = rowBorders;
         this.stripeRows = stripeRows;
+        this.showCellFocus = showCellFocus;
 
         this.colChooserModel = enableColChooser ? this.createChooserModel() : null;
         this.selModel = this.parseSelModel(selModel);

--- a/cmp/grid/ag-grid/styles.scss
+++ b/cmp/grid/ag-grid/styles.scss
@@ -176,20 +176,33 @@
       padding-left: var(--xh-grid-compact-cell-lr-pad-px);
       padding-right: var(--xh-grid-compact-cell-lr-pad-px);
     }
-
   }
 
 
   //------------------------
   // Other Optional Modifiers + Overrides
   //------------------------
-  .ag-cell-focus {
-    border-color: var(--xh-grid-cell-focus-border-color) !important;
-    outline: 0 !important;
-  }
-
   &--highlight-on-hover .ag-row.ag-row-hover:not(.ag-row-group):not(.ag-row-selected) {
     background-color: var(--xh-grid-bg-hover);
+  }
+
+  // Restore right border on cells - not included by default with ag-grid but
+  // causes right-aligned content to shift by one pixel when focused.
+  .ag-cell.ag-cell-no-focus {
+    border-right: 1px solid transparent;
+  }
+
+  // Disable default cell focus outline/border.
+  .ag-cell-focus {
+    outline: 0 !important;
+    border-color: transparent !important;
+  }
+
+  // Unless enabled by extra class/flag - then restore.
+  &--show-cell-focus {
+    .ag-cell-focus {
+      border-color: var(--xh-grid-cell-focus-border-color) !important;
+    }
   }
 
   // Grouped rows appear slightly misaligned (standard mode only)

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -74,8 +74,8 @@ body {
   --xh-grid-bg-hover: var(--grid-bg-hover, #{mc-trans('blue', '200', 0.8)});
   --xh-grid-bg-highlight: var(--grid-bg-highlight, var(--xh-bg-highlight));
   --xh-grid-bg-odd: var(--grid-bg-odd, #{mc('grey', '100')});
-  --xh-grid-border-color: var(--grid-border-color, #{mc('grey', '300')});
-  --xh-grid-cell-focus-border-color: var(--grid-cell-focus-border-color, transparent);
+  --xh-grid-border-color: var(--grid-border-color, #{mc('grey', '200')});
+  --xh-grid-cell-focus-border-color: var(--grid-cell-focus-border-color, var(--xh-focus-outline-color));
   --xh-grid-cell-lr-pad: var(--grid-cell-lr-pad, 11);
   --xh-grid-cell-lr-pad-px: calc(var(--xh-grid-cell-lr-pad) * 1px);
   --xh-grid-empty-text-color: var(--grid-empty-text-color, var(--xh-text-color-muted));


### PR DESCRIPTION
+ Fixes #946
+ Tweak to also avoid (existing) shifting on right-aligned focused cells
+ Lighten up grid row borders in general if shown