### PR TITLE
Use onKeyDown rather than onKeyPress consistently across HoistInputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## v21.0.0-SNAPSHOT (under development)
 
-* TBD
+### 💥 Breaking Changes
+
+* Multiple HoistInputs have changed their `onKeyPress` props to `onKeyDown`. TextInput, NumberInput,
+  TextArea & SearchInput have been changed.
 
 ## v20.2.0 - 2019-03-27
 

--- a/desktop/appcontainer/LoginPanel.js
+++ b/desktop/appcontainer/LoginPanel.js
@@ -52,7 +52,7 @@ export class LoginPanel extends Component {
                             placeholder: 'Username...',
                             autoFocus: true,
                             commitOnChange: true,
-                            onKeyPress: this.onKeyPress,
+                            onKeyDown: this.onKeyDown,
                             autoComplete: 'on',
                             width: null
                         }),
@@ -62,7 +62,7 @@ export class LoginPanel extends Component {
                             placeholder: 'Password...',
                             type: 'password',
                             commitOnChange: true,
-                            onKeyPress: this.onKeyPress,
+                            onKeyDown: this.onKeyDown,
                             autoComplete: 'on',
                             width: null
                         }),
@@ -96,7 +96,7 @@ export class LoginPanel extends Component {
         this.model.submit();
     };
 
-    onKeyPress = (ev) => {
+    onKeyDown = (ev) => {
         if (ev.key === 'Enter') {
             this.onSubmit();
         }

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -120,7 +120,7 @@ export class DateInput extends HoistInput {
 
                 onBlur: this.onBlur,
                 onFocus: this.onFocus,
-                onKeyPress: this.onKeyPress
+                onKeyDown: this.onKeyDown
             },
             // See Hoist #757. Blueprint setting arbitrary, narrower limits without these
             maxDate: props.maxDate || moment().add(100, 'years').toDate(),
@@ -202,7 +202,7 @@ export class DateInput extends HoistInput {
         this.forcePopoverClose();
     };
 
-    onKeyPress = (ev) => {
+    onKeyDown = (ev) => {
         if (ev.key == 'Enter') this.doCommit();
     };
 

--- a/desktop/cmp/input/NumberInput.js
+++ b/desktop/cmp/input/NumberInput.js
@@ -67,8 +67,8 @@ export class NumberInput extends HoistInput {
         /** Minor step size for increment/decrement handling. */
         minorStepSize: PT.number,
 
-        /** Callback for normalized keypress event. */
-        onKeyPress: PT.func,
+        /** Callback for normalized keydown event. */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty. */
         placeholder: PT.string,
@@ -131,7 +131,7 @@ export class NumberInput extends HoistInput {
             },
             onBlur: this.onBlur,
             onFocus: this.onFocus,
-            onKeyPress: this.onKeyPress,
+            onKeyDown: this.onKeyDown,
             onValueChange: this.onValueChange
         });
     }
@@ -145,9 +145,9 @@ export class NumberInput extends HoistInput {
         return isNaN(val) ? null : val;
     }
 
-    onKeyPress = (ev) => {
+    onKeyDown = (ev) => {
         if (ev.key === 'Enter') this.doCommit();
-        if (this.props.onKeyPress) this.props.onKeyPress(ev);
+        if (this.props.onKeyDown) this.props.onKeyDown(ev);
     }
 
     formatRenderValue(value) {

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -206,7 +206,7 @@ export class Select extends HoistInput {
             item: factory(rsProps),
             className: this.getClassName(),
             onKeyDown: (e) => {
-                // Esc. and Enter can be listened for by parents -- stop the keypress event
+                // Esc. and Enter can be listened for by parents -- stop the keydown event
                 // propagation only if react-select already likely to have used for menu management.
                 const {menuIsOpen} = this.reactSelectRef.current ? this.reactSelectRef.current.state : {};
                 if (menuIsOpen && (e.key == 'Escape' || e.key == 'Enter')) {

--- a/desktop/cmp/input/TextArea.js
+++ b/desktop/cmp/input/TextArea.js
@@ -33,6 +33,9 @@ export class TextArea extends HoistInput {
         /** True to take up the full width of container. */
         fill: PT.bool,
 
+        /** Callback for normalized keydown event. */
+        onKeyDown: PT.func,
+
         /** True to select contents when control receives focus. */
         selectOnFocus: PT.bool,
 
@@ -75,7 +78,7 @@ export class TextArea extends HoistInput {
             onBlur: this.onBlur,
             onChange: this.onChange,
             onFocus: this.onFocus,
-            onKeyPress: this.onKeyPress
+            onKeyDown: this.onKeyDown
         });
     }
 
@@ -83,8 +86,9 @@ export class TextArea extends HoistInput {
         this.noteValueChange(ev.target.value);
     };
 
-    onKeyPress = (ev) => {
+    onKeyDown = (ev) => {
         if (ev.key === 'Enter' && !ev.shiftKey) this.doCommit();
+        if (this.props.onKeyDown) this.props.onKeyDown(ev);
     };
 
     onFocus = (ev) => {

--- a/desktop/cmp/input/TextInput.js
+++ b/desktop/cmp/input/TextInput.js
@@ -48,8 +48,8 @@ export class TextInput extends HoistInput {
         /** Icon to display inline on the left side of the input. */
         leftIcon: PT.element,
 
-        /** Callback for normalized keypress event. */
-        onKeyPress: PT.func,
+        /** Callback for normalized keydown event. */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty. */
         placeholder: PT.string,
@@ -108,7 +108,7 @@ export class TextInput extends HoistInput {
                 },
 
                 onChange: this.onChange,
-                onKeyPress: this.onKeyPress
+                onKeyDown: this.onKeyDown
             }),
 
             className: this.getClassName(),
@@ -137,9 +137,9 @@ export class TextInput extends HoistInput {
         this.noteValueChange(ev.target.value);
     };
 
-    onKeyPress = (ev) => {
+    onKeyDown = (ev) => {
         if (ev.key === 'Enter') this.doCommit();
-        if (this.props.onKeyPress) this.props.onKeyPress(ev);
+        if (this.props.onKeyDown) this.props.onKeyDown(ev);
     }
 
     onFocus = (ev) => {

--- a/mobile/cmp/input/NumberInput.js
+++ b/mobile/cmp/input/NumberInput.js
@@ -45,8 +45,8 @@ export class NumberInput extends HoistInput {
         /** Onsen modifier string */
         modifier: PT.string,
 
-        /** Function which receives keypress event */
-        onKeyPress: PT.func,
+        /** Function which receives keydown event */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty */
         placeholder: PT.string,
@@ -99,7 +99,7 @@ export class NumberInput extends HoistInput {
             spellCheck: false,
 
             onChange: this.onChange,
-            onKeyPress: this.onKeyPress,
+            onKeyDown: this.onKeyDown,
             onBlur: this.onBlur,
             onFocus: this.onFocus
         });
@@ -111,10 +111,10 @@ export class NumberInput extends HoistInput {
         this.noteValueChange(value);
     };
 
-    onKeyPress = (ev) => {
-        const {onKeyPress} = this.props;
+    onKeyDown = (ev) => {
+        const {onKeyDown} = this.props;
         if (ev.key === 'Enter') this.doCommit();
-        if (onKeyPress) onKeyPress(ev);
+        if (onKeyDown) onKeyDown(ev);
     };
 
     onFocus = (ev) => {

--- a/mobile/cmp/input/SearchInput.js
+++ b/mobile/cmp/input/SearchInput.js
@@ -28,8 +28,8 @@ export class SearchInput extends HoistInput {
         /** Onsen modifier string */
         modifier: PT.string,
 
-        /** Function which receives keypress event */
-        onKeyPress: PT.func,
+        /** Function which receives keydown event */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty */
         placeholder: PT.string,
@@ -72,7 +72,7 @@ export class SearchInput extends HoistInput {
             },
 
             onChange: this.onChange,
-            onKeyPress: this.onKeyPress,
+            onKeyDown: this.onKeyDown,
             onBlur: this.onBlur,
             onFocus: this.onFocus
         });
@@ -82,10 +82,10 @@ export class SearchInput extends HoistInput {
         this.noteValueChange(ev.target.value);
     };
 
-    onKeyPress = (ev) => {
-        const {onKeyPress} = this.props;
+    onKeyDown = (ev) => {
+        const {onKeyDown} = this.props;
         if (ev.key === 'Enter') this.doCommit();
-        if (onKeyPress) onKeyPress(ev);
+        if (onKeyDown) onKeyDown(ev);
     };
 
     onFocus = (ev) => {

--- a/mobile/cmp/input/TextArea.js
+++ b/mobile/cmp/input/TextArea.js
@@ -30,8 +30,8 @@ export class TextArea extends HoistInput {
         /** Height of the control in pixels. */
         height: PT.number,
 
-        /** Function which receives keypress event */
-        onKeyPress: PT.func,
+        /** Function which receives keydown event */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty */
         placeholder: PT.string,
@@ -63,7 +63,7 @@ export class TextArea extends HoistInput {
                 tabIndex: props.tabIndex,
 
                 onChange: this.onChange,
-                onKeyPress: this.onKeyPress,
+                onKeyDown: this.onKeyDown,
                 onBlur: this.onBlur,
                 onFocus: this.onFocus
             }),
@@ -81,9 +81,9 @@ export class TextArea extends HoistInput {
         this.noteValueChange(ev.target.value);
     };
 
-    onKeyPress = (ev) => {
-        const {onKeyPress} = this.props;
-        if (onKeyPress) onKeyPress(ev);
+    onKeyDown = (ev) => {
+        const {onKeyDown} = this.props;
+        if (onKeyDown) onKeyDown(ev);
     };
 
     onFocus = (ev) => {

--- a/mobile/cmp/input/TextInput.js
+++ b/mobile/cmp/input/TextInput.js
@@ -41,8 +41,8 @@ export class TextInput extends HoistInput {
         /** Onsen modifier string */
         modifier: PT.string,
 
-        /** Function which receives keypress event */
-        onKeyPress: PT.func,
+        /** Function which receives keydown event */
+        onKeyDown: PT.func,
 
         /** Text to display when control is empty */
         placeholder: PT.string,
@@ -90,7 +90,7 @@ export class TextInput extends HoistInput {
             },
 
             onChange: this.onChange,
-            onKeyPress: this.onKeyPress,
+            onKeyDown: this.onKeyDown,
             onBlur: this.onBlur,
             onFocus: this.onFocus
         });
@@ -100,10 +100,10 @@ export class TextInput extends HoistInput {
         this.noteValueChange(ev.target.value);
     };
 
-    onKeyPress = (ev) => {
-        const {onKeyPress} = this.props;
+    onKeyDown = (ev) => {
+        const {onKeyDown} = this.props;
         if (ev.key === 'Enter') this.doCommit();
-        if (onKeyPress) onKeyPress(ev);
+        if (onKeyDown) onKeyDown(ev);
     };
 
     onFocus = (ev) => {


### PR DESCRIPTION
Also added onKeyDown prop to desktop TextArea, for symmetry with other inputs & mobile.
#1040