### PR TITLE
Remove confusing getter FormModel.isNotValid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v21.0.0-SNAPSHOT (under development)
 
+### 💥 Breaking Changes
+* The shortcut getter `FormModel.isNotValid` was deemed confusing and has been removed from the API.   In most cases 
+    applications should use `!FormModel.isValid` instead; this expresssion will return `false` for the `Unknown` as 
+    well as the `NotValid` state.  Applications that wish to explicitly test for the `NotValid` state should use the
+   `validationState` gettter. 
+   
+ 
 * TBD
 
 ## v20.2.0 - 2019-03-27

--- a/cmp/form/FormModel.js
+++ b/cmp/form/FormModel.js
@@ -153,11 +153,6 @@ export class FormModel {
         return this.validationState == ValidationState.Valid;
     }
 
-    /** @member {boolean} - true if any fields are not valid. */
-    get isNotValid() {
-        return this.validationState == ValidationState.NotValid;
-    }
-
     /** @member {String[]} - list of all validation errors for this form. */
     get allErrors() {
         return flatMap(this.fields, s => s.allErrors);


### PR DESCRIPTION
The fact that formModel.isNotValid is not *always* equal to !formModel.isValid caught Arjun up.

See the changelog for a description of the reasoning behind removing this.  I doubt it is widely used.