### PR TITLE
Fix: Changing / reordering children within a FormContext can throw an Error

### DIFF
--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -138,6 +138,7 @@ export class FormField extends Component {
         const control = this.prepareChild({displayNotValid, errors, idAttr, leftErrorIcon, minimal, readonly});
 
         return box({
+            key: fieldModel ? fieldModel.xhId : null,
             items: [
                 labelEl({
                     omit: !label,
@@ -230,7 +231,6 @@ export class FormField extends Component {
             {propTypes} = item.type;
 
         const overrides = {
-            key: fieldModel ? fieldModel.xhId : null,
             model: fieldModel,
             bind: 'value',
             disabled: fieldModel && fieldModel.disabled,

--- a/desktop/cmp/form/FormField.js
+++ b/desktop/cmp/form/FormField.js
@@ -230,6 +230,7 @@ export class FormField extends Component {
             {propTypes} = item.type;
 
         const overrides = {
+            key: fieldModel ? fieldModel.xhId : null,
             model: fieldModel,
             bind: 'value',
             disabled: fieldModel && fieldModel.disabled,


### PR DESCRIPTION
See issue: https://github.com/exhi/hoist-react/issues/1031