### PR TITLE
Add gridModel.groupSortFn for custom group sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * A new `DockContainer` component provides a user-friendly way to render multiple child components
   "docked" to its bottom edge. Each child view is rendered with a configurable header and controls
   to allow the user to expand it, collapse it, or optionally "pop it out" into a modal dialog.
+* Added `GridModel.groupSortFn` config to support custom group sorting (replaces any use of
+  `agOptions.defaultGroupSortComparator`).
 
 ## v21.0.0 - 2019-04-04
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -184,7 +184,6 @@ export class Grid extends Component {
                 menuTabs: ['filterMenuTab']
             },
             popupParent: document.querySelector('body'),
-            defaultGroupSortComparator: this.sortByGroup,
             headerHeight: props.hideHeaders ? 0 : undefined,
             icons: {
                 groupExpanded: convertIconToSvg(
@@ -215,6 +214,7 @@ export class Grid extends Component {
             onColumnRowGroupChanged: this.onColumnRowGroupChanged,
             onColumnVisible: this.onColumnVisible,
             processCellForClipboard: this.processCellForClipboard,
+            defaultGroupSortComparator: model.groupSortFn,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true,
             autoGroupColumnDef: {
@@ -325,16 +325,6 @@ export class Grid extends Component {
         items = dropRightWhile(items, it => it === 'separator');
         items = dropWhile(items, it => it === 'separator');
         return items;
-    }
-
-    sortByGroup(nodeA, nodeB) {
-        if (nodeA.key < nodeB.key) {
-            return -1;
-        } else if (nodeA.key > nodeB.key) {
-            return 1;
-        } else {
-            return 0;
-        }
     }
 
     //------------------------

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -214,7 +214,7 @@ export class Grid extends Component {
             onColumnRowGroupChanged: this.onColumnRowGroupChanged,
             onColumnVisible: this.onColumnVisible,
             processCellForClipboard: this.processCellForClipboard,
-            defaultGroupSortComparator: model.groupSortFn,
+            defaultGroupSortComparator: this.groupSortComparator,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true,
             autoGroupColumnDef: {
@@ -539,6 +539,11 @@ export class Grid extends Component {
         }
     };
 
+    groupSortComparator = (nodeA, nodeB) => {
+        const gridModel = this.model;
+        return gridModel.groupSortFn(nodeA.key, nodeB.key, nodeA.field, {gridModel, nodeA, nodeB});
+    };
+
     doWithPreservedState({expansion, filters}, fn) {
         const expandState = expansion ? this.readExpandState() : null,
             filterState = filters ? this.readFilterState() : null;
@@ -582,5 +587,6 @@ export class Grid extends Component {
     processCellForClipboard({value, node, column}) {
         return column.isTreeColumn ? node.data[column.field] : value;
     }
+
 }
 export const grid = elemFactory(Grid);

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -66,9 +66,9 @@ export class GridModel {
     colChooserModel;
     /** @member {function} */
     rowClassFn;
-    /** @member {function} */
+    /** @member {GridStoreContextMenuFn} */
     contextMenuFn;
-    /** @member {function} */
+    /** @member {GridGroupSortFn} */
     groupSortFn;
     /** @member {boolean} */
     enableExport;
@@ -141,8 +141,8 @@ export class GridModel {
      * @param {object} [c.exportOptions] - default options used in exportAsync().
      * @param {function} [c.rowClassFn] - closure to generate css class names for a row.
      *      Called with record data, returns a string or array of strings.
-     * @param {function} [c.groupSortFn] - closure to sort full-row groups. Called with two nodes to
-     *      be compared, returns a number as per a standard JS comparator.
+     * @param {GridGroupSortFn} [c.groupSortFn] - closure to sort full-row groups. Called with two
+     *      group values to compare, returns a number as per a standard JS comparator.
      * @param {GridStoreContextMenuFn} [c.contextMenuFn] - function to optionally return a
      *      StoreContextMenu when the grid is right-clicked (desktop only).
      * @param {*} [c...rest] - additional data to attach to this model instance.
@@ -647,8 +647,7 @@ export class GridModel {
         });
     }
 
-    defaultGroupSortFn = (nodeA, nodeB) => {
-        const a = nodeA.key, b = nodeB.key;
+    defaultGroupSortFn = (a, b) => {
         return a < b ? -1 : (a > b ? 1 : 0);
     }
 
@@ -659,6 +658,18 @@ export class GridModel {
  * @property {string} colId - unique identifier of the column
  * @property {number} [width] - new width to set for the column
  * @property {boolean} [hidden] - visibility of the column
+ */
+
+/**
+ * @callback GridGroupSortFn - comparator for custom grid group sorting, provided to GridModel.
+ * @param {*} groupAVal - first group value to be compared.
+ * @param {*} groupBVal - second group value to be compared.
+ * @param {string} groupField - field name being grouped at this level.
+ * @param {Object} metadata - additional metadata with raw ag-Grid group nodes.
+ * @param {GridModel} metadata.gridModel - controlling GridModel.
+ * @param {RowNode} metadata.nodeA - first raw ag-Grid row node.
+ * @param {RowNode} metadata.nodeB - second raw ag-Grid row node.
+ * @returns {number} - 0 if group values are equal, <0 if `a` sorts first, >0 if `b` sorts first.
  */
 
 /**


### PR DESCRIPTION
+ Relays to defaultGroupSortCompator, avoid need to use agOptions.
+ Keep existing default that sorts groups according to their natural order.
+ Tweak contextMenuFn config handling for symmetry (requires review).
+ Remove unused/dupe init values on class fields declarations.