### PR TITLE
Grid Context Menu should suppress Browser Menu

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -238,7 +238,8 @@ export class Grid extends Component {
             ret = {
                 ...ret,
                 allowContextMenuWithControlKey: true,
-                getContextMenuItems: this.getContextMenuItems
+                getContextMenuItems: this.getContextMenuItems,
+                onCellContextMenu: this.onCellContextMenu
             };
         }
 
@@ -280,6 +281,12 @@ export class Grid extends Component {
         if (!record) selModel.clear();
 
         return this.buildMenuItems(menu.items, record, selModel.records);
+    };
+
+    onCellContextMenu = () => {
+        // Suppress the browser's context menu when the grid's context menu is right-clicked
+        const agMenu = document.getElementsByClassName('ag-menu-list');
+        if (agMenu.length) agMenu[0].oncontextmenu = () => false;
     };
 
     buildMenuItems(recordActions, record, selectedRecords) {


### PR DESCRIPTION
Not the most elegant solution, but tough because Ag's context menu API is pretty minimal. 

Limitation is that this fix fails when `onCellContextMenu` passed via agOptions. I suppose that falls under our agOptions disclaimer, though.

Signed-off-by: shravnk <brendan.ode4@gmail.com>