### PR TITLE
Add Store.removeAllRecords()

### DIFF
--- a/admin/tabs/general/configs/differ/ConfigDifferModel.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferModel.js
@@ -138,7 +138,7 @@ export class ConfigDifferModel  {
     }
 
     processFailedLoad() {
-        this.gridModel.store.loadData([]);
+        this.gridModel.store.removeAllRecords();
     }
 
     diffConfigs(localConfigs, remoteConfigs) {

--- a/admin/tabs/general/configs/differ/ConfigDifferModel.js
+++ b/admin/tabs/general/configs/differ/ConfigDifferModel.js
@@ -138,7 +138,7 @@ export class ConfigDifferModel  {
     }
 
     processFailedLoad() {
-        this.gridModel.store.removeAllRecords();
+        this.gridModel.store.clear();
     }
 
     diffConfigs(localConfigs, remoteConfigs) {

--- a/data/Store.js
+++ b/data/Store.js
@@ -96,6 +96,11 @@ export class Store {
         this.lastUpdated = Date.now();
     }
 
+    /** Clear all records from the store. */
+    removeAllRecords() {
+        this.loadData([]);
+    }
+
     /**
      * Remove a record (and all its children, if any) from the store.
      * @param {(string[]|number[])} ids - IDs of the records to be removed.

--- a/data/Store.js
+++ b/data/Store.js
@@ -96,8 +96,8 @@ export class Store {
         this.lastUpdated = Date.now();
     }
 
-    /** Clear all records from the store. */
-    removeAllRecords() {
+    /** Remove all records from the store. */
+    clear() {
         this.loadData([]);
     }
 


### PR DESCRIPTION
A low pressure pull request here. This seemed like a useful-enough convenience method, and I can imagine it being helpful to have an official API for efficient clearing vs. apps calling `loadData([])` as they do currently.

Initially called it `clear()` and would like the short name, but consistency with existing `removeRecords(ids)` seemed worth it.