### PR TITLE
ag-Grid State Serialization

### DIFF
--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -61,11 +61,6 @@ export class AgGridModel {
         });
     }
 
-    logStateDebugInfo() {
-        const state = this.getState();
-        console.log('Current State:', state);
-    }
-
     getState({excludeSort, excludeExpand, excludeFilter, excludeSideBarState} = {}) {
         const {agColumnApi} = this,
             pivotMode = agColumnApi.isPivotMode(),

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -164,16 +164,20 @@ export class AgGridModel {
      */
     getSortState() {
         const {agApi, agColumnApi} = this,
-            sortModel = agApi.getSortModel(),
             isPivot = agColumnApi.isPivotMode();
 
         // When we have pivot columns we need to make sure we store the path to the sorted column
         // using the pivot keys and value column id, instead of using the auto-generate secondary
         // column id as this could be different with different data or even with the same data based
         // on the state of the grid when pivot mode was turned on
+        let sortModel = agApi.getSortModel();
         if (isPivot && !isEmpty(agColumnApi.getPivotColumns())) {
-            const secondaryCols = agColumnApi.getSecondaryColumns();
+            // ag-Grid may have left sort state in the model from before pivot mode was activated,
+            // which is not representative of the current grid state, so we need to remove any sorts
+            // on non-pivot columns
+            sortModel = sortModel.filter(it => it.colId.startsWith('pivot_'));
 
+            const secondaryCols = agColumnApi.getSecondaryColumns();
             sortModel.forEach(sort => {
                 const col = secondaryCols.find(it => it.colId === sort.colId);
                 sort.colId = this.getPivotColumnId(col);

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -222,6 +222,7 @@ export class Grid extends Component {
             defaultGroupSortComparator: this.groupSortComparator,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true,
+            rememberGroupStateWhenNewData: true,
             autoGroupColumnDef: {
                 suppressSizeToFit: true // Without this the auto group col will get shrunk when we size to fit
             }

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -222,7 +222,7 @@ export class Grid extends Component {
             defaultGroupSortComparator: this.groupSortComparator,
             groupDefaultExpanded: 1,
             groupUseEntireRow: true,
-            rememberGroupStateWhenNewData: true,
+            rememberGroupStateWhenNewData: true, // turning this on by default so group state is maintained when apps are not using deltaRowDataMode
             autoGroupColumnDef: {
                 suppressSizeToFit: true // Without this the auto group col will get shrunk when we size to fit
             }
@@ -420,7 +420,7 @@ export class Grid extends Component {
             run: ([api]) => {
                 if (!api) return;
 
-                this.doWithPreservedState({expansion: true, filters: true}, () => {
+                this.doWithPreservedState({expansion: false, filters: true}, () => {
                     api.setColumnDefs(this.getColumnDefs());
                 });
                 api.sizeColumnsToFit();
@@ -474,7 +474,7 @@ export class Grid extends Component {
                     };
                 });
 
-                this.doWithPreservedState({expansion: true}, () => {
+                this.doWithPreservedState({expansion: false}, () => {
                     colApi.setColumnState(colState);
                 });
                 api.sizeColumnsToFit();

--- a/core/appcontainer/OptionsDialogModel.js
+++ b/core/appcontainer/OptionsDialogModel.js
@@ -88,7 +88,7 @@ export class OptionsDialogModel {
         }
 
         this.doSaveAsync()
-            .wait(reloadApp ? 1500 : 1)
+            .wait(1000)
             .then(() => {
                 this.hide();
                 if (reloadApp) {


### PR DESCRIPTION
Support for serialization of the ag-Grid state via AgGridModel.

Supports serialization of:
- Column state
- Pivot Mode on/off
- Sort config
- Filters (optional)
- Row group expand state (optional)
- Side bar state (currently opened panel) (optional)

Some of the state is data dependent, and it is important that it not be set until after data has been loaded, and should be understood that the state may not be valid for different data sets. The state which is data dependent is:
- Filters (specifically the excel style set filters)
- Expand state (depends on the row group keys)
- Sort config (only when in pivot mode - depends on the pivot keys)

TODO
- [ ] Doc comments
- [ ] Address TODOs around validating the state before applying via the ag-Grid APIs (remove refs to invalid columns)
- [ ] Consider separation of data-dependent state from non-data-dependent state
- [ ] Consider overriding default ag-Grid behavior when toggling pivot mode (differences in how columns are determined to be "visible" - hide vs value)
