### PR TITLE
`Promise.track` now accepts an optional `omit` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 * `ButtonGroupInput` accepts a new `enableClear` prop that allows the active / depressed button to
   be unselected by pressing it again - this sets the value of the input as a whole to `null`.
 * Hoist Admins now always see the VersionBar in the footer.
+* `Promise.track` now accepts an optional `omit` config that indicates when no tracking will be 
+  performed.
 
 ### 💥 Breaking Changes
 

--- a/promise/Promise.js
+++ b/promise/Promise.js
@@ -133,11 +133,12 @@ Object.assign(Promise.prototype, {
      * @see TrackService.track()
      *
      * @param {Object} [trackCfg] - valid options object for TrackService.track().
-     *      If null, no tracking will be performed (useful when trackCfg conditionally generated -
-     *      i.e. to suppress tracking for auto-refresh calls triggered by a Timer).
+     * @param {boolean} [trackCfg.omit] - optional to indicate when no tracking will be performed
+     *      (useful when trackCfg conditionally generated - i.e. to suppress tracking for
+     *      auto-refresh calls triggered by a Timer).
      */
     track(trackCfg) {
-        if (!trackCfg) return this;
+        if (!trackCfg || trackCfg.omit) return this;
 
         if (typeof trackCfg === 'string') {
             trackCfg = {message: trackCfg};


### PR DESCRIPTION
Issue #1111 
Also linted and updated change log