### PR TITLE
Format number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 * Hoist Admins now always see the VersionBar in the footer.
 * `Promise.track` now accepts an optional `omit` config that indicates when no tracking will be 
   performed.
+* `formatNumber` now accepts an optional `prefix` config that prepends immediately before the 
+  number, but after the sign (`+`, `-`).   
 
 ### 💥 Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Hoist Admins now always see the VersionBar in the footer.
 * `Promise.track` now accepts an optional `omit` config that indicates when no tracking will be 
   performed.
-* `formatNumber` now accepts an optional `prefix` config that prepends immediately before the 
+* `fmtNumber` now accepts an optional `prefix` config that prepends immediately before the 
   number, but after the sign (`+`, `-`).   
 
 ### 💥 Breaking Changes

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -253,17 +253,20 @@ function fmtNumberElement(v, opts = {}) {
 function fmtNumberString(v, opts = {}) {
     const {ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, prefix} = opts;
     let str = opts.str;
+    const strOriginal = str;
 
     if (withSignGlyph) {
-        str = signGlyph(v) + '&nbsp;' + str;
+        str = signGlyph(v) + '&nbsp;';
     }
 
     if (isString(prefix)) {
-        if (v < 0) {
-            console.log('v < 0; \n \n this is the str!: ', str);
+        if (strOriginal.startsWith('-') || strOriginal.startsWith('+')) {
+            str += (strOriginal[0] + '$' + strOriginal.substring(1));
         } else {
-            console.log('this is the str!: ', str);
+            str += ('$' + strOriginal);
         }
+    } else {
+        str += strOriginal;
     }
 
     if (isString(label)) {

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -63,6 +63,7 @@ export function fmtNumber(v, {
     withPlusSign = false,
     withSignGlyph = false,
     label = null,
+    prefix = null,
     labelCls = 'xh-units-label',
     colorSpec = null,
     tooltip = null,
@@ -80,7 +81,7 @@ export function fmtNumber(v, {
         str = '+' + str;
     }
 
-    const opts = {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, originalValue};
+    const opts = {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, originalValue, prefix};
     return asElement ? fmtNumberElement(v, opts) : fmtNumberString(v, opts);
 }
 
@@ -203,7 +204,7 @@ export function fmtNumberTooltip(v, {ledger = false} = {}) {
 // Implementation
 //---------------
 function fmtNumberElement(v, opts = {}) {
-    const {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip} = opts;
+    const {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, prefix} = opts;
 
     // CSS classes
     const cls = [];
@@ -219,6 +220,10 @@ function fmtNumberElement(v, opts = {}) {
     }
 
     items.push(str);
+
+    if (isString(prefix)) {
+        items.unshift(prefix);
+    }
 
     if (isString(label)) {
         items.push(labelCls ? fmtSpan(label, {className: labelCls, asElement: asElement}) : label);
@@ -242,11 +247,15 @@ function fmtNumberElement(v, opts = {}) {
 }
 
 function fmtNumberString(v, opts = {}) {
-    const {ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip} = opts;
+    const {ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, prefix} = opts;
     let str = opts.str;
 
     if (withSignGlyph) {
         str = signGlyph(v) + '&nbsp;' + str;
+    }
+
+    if (isString(prefix)) {
+        str = prefix + str;
     }
 
     if (isString(label)) {

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -80,7 +80,7 @@ export function fmtNumber(v, {
 
     if (v > 0 && withPlusSign) {
         sign = '+';
-    } else if (v < 0) {
+    } else if (v < 0 && !ledger) {
         sign = '-';
     }
 
@@ -220,9 +220,7 @@ function fmtNumberElement(v, opts = {}) {
 
     if (withSignGlyph) {
         items.push(signGlyph(v, asElement));
-    }
-
-    if (sign && !withSignGlyph && !ledger) {
+    } else if (sign) {
         items.push(sign);
     }
 
@@ -258,10 +256,8 @@ function fmtNumberString(v, opts = {}) {
     let ret = '';
 
     if (withSignGlyph) {
-        ret = signGlyph(v) + '&nbsp;';
-    }
-
-    if (sign && !withSignGlyph && !ledger) {
+        ret += signGlyph(v) + '&nbsp;';
+    } else if (sign) {
         ret += sign;
     }
 

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -219,10 +219,14 @@ function fmtNumberElement(v, opts = {}) {
         items.push(signGlyph(v, asElement));
     }
 
-    items.push(str);
-
     if (isString(prefix)) {
-        items.unshift(prefix);
+        if (str.startsWith('-') || str.startsWith('+')) {
+            items.push(str[0], '$', str.substring(1));
+        } else {
+            items.push('$', str);
+        }
+    } else {
+        items.push(str);
     }
 
     if (isString(label)) {
@@ -255,7 +259,11 @@ function fmtNumberString(v, opts = {}) {
     }
 
     if (isString(prefix)) {
-        str = prefix + str;
+        if (v < 0) {
+            console.log('v < 0; \n \n this is the str!: ', str);
+        } else {
+            console.log('this is the str!: ', str);
+        }
     }
 
     if (isString(label)) {

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -63,8 +63,8 @@ export function fmtNumber(v, {
     forceLedgerAlign = true,
     withPlusSign = false,
     withSignGlyph = false,
-    label = null,
     prefix = null,
+    label = null,
     labelCls = 'xh-units-label',
     colorSpec = null,
     tooltip = null,
@@ -77,12 +77,7 @@ export function fmtNumber(v, {
     formatConfig = formatConfig || buildFormatConfig(v, precision, zeroPad);
     let str = numbro(v).format(formatConfig);
 
-    if (ledger || withSignGlyph) str = str.replace('-', '');
-    if (withPlusSign && v > 0) {
-        str = '+' + str;
-    }
-
-    const opts = {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, originalValue, prefix};
+    const opts = {str, ledger, forceLedgerAlign, withSignGlyph, prefix, label, labelCls, colorSpec, tooltip, originalValue};
     return asElement ? fmtNumberElement(v, opts) : fmtNumberString(v, opts);
 }
 
@@ -205,7 +200,8 @@ export function fmtNumberTooltip(v, {ledger = false} = {}) {
 // Implementation
 //---------------
 function fmtNumberElement(v, opts = {}) {
-    const {str, ledger, forceLedgerAlign, withSignGlyph, label, labelCls, colorSpec, tooltip, prefix} = opts;
+    const {ledger, forceLedgerAlign, withPlusSign, withSignGlyph, prefix, label, labelCls, colorSpec, tooltip} = opts;
+    let str = opts.str;
 
     // CSS classes
     const cls = [];
@@ -216,15 +212,24 @@ function fmtNumberElement(v, opts = {}) {
     const asElement = true,
         items = [];
 
+    // 1. format str according to later needs
+    if (ledger || withSignGlyph) {
+        str = str.replace('-', '');
+    } else if (withPlusSign && v > 0) {
+        str = '+' + str;
+    }
+
+
+    // 2. add prepends
     if (withSignGlyph) {
         items.push(signGlyph(v, asElement));
     }
 
     if (isString(prefix)) {
         if (str.startsWith('-') || str.startsWith('+')) {
-            items.push(str[0], '$', str.substring(1));
+            items.push(str[0], prefix, str.substring(1));
         } else {
-            items.push('$', str);
+            items.push(prefix, str);
         }
     } else {
         items.push(str);

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -38,6 +38,7 @@ const UP_TICK = '▴',
  *      align vertically with negative ledgers in columns.
  * @param {boolean} [opts.withPlusSign] - true to prepend positive numbers with a '+'.
  * @param {boolean} [opts.withSignGlyph] - true to prepend an up / down arrow.
+ * @param {string} [opts.prefix] - prefix to prepend to value (between the number and its sign).
  * @param {string} [opts.label] - label to append to value.
  * @param {string} [opts.labelCls] - CSS class of label <span>,
  * @param {(boolean|Object)} [opts.colorSpec] - show in colored <span>, based on sign of value.


### PR DESCRIPTION
`formatNumber` now accepts an optional `prefix` config to be prepended to value:

+ Re: ticket #1067, and its specified use case for dollar signs (`$`)
+ `prefix` before the number, but after the sign (if any)
+  e.g., `-$13.37` or `+$5.20`
