### PR TITLE
FileChooser.enableMulti actually to accept multiple files in single upload Issue # 1069

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ execution of time-consuming loops.
   once again able to apply remote config values.
 * A `Panel` with configs `resizable: true, collapsible: false` now renders with a splitter.
 * A `Panel` with no `icon`, `title`, or `headerItems` will not render a blank header. 
+* `FileChooser.enableMulti` now behaves as one might expect -- true to allow multiple files in a 
+  single upload.  Previous behavior (the ability to add multiple files to dropzone) is
+  now controlled by `enableAddMulti`
+
 
 ## v22.0.0 - 2019-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ execution of time-consuming loops.
 * A `Panel` with no `icon`, `title`, or `headerItems` will not render a blank header. 
 * `FileChooser.enableMulti` now behaves as one might expect -- true to allow multiple files in a 
   single upload.  Previous behavior (the ability to add multiple files to dropzone) is
-  now controlled by `enableAddMulti`
+  now controlled by `enableAddMulti`.
 
 
 ## v22.0.0 - 2019-04-29

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -111,10 +111,7 @@ export class FileChooser extends Component {
                             )
                         });
                     },
-                    onDrop: (accepted, rejected) => {
-
-                        this.model.onDrop(accepted, rejected, enableMulti);
-                    }
+                    onDrop: (accepted, rejected) => this.model.onDrop(accepted, rejected, enableMulti)
                 }),
                 grid({
                     model: gridModel,

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -40,7 +40,7 @@ export class FileChooser extends Component {
         /** File type(s) to accept (e.g. `['.doc', '.docx', '.pdf']`). */
         accept: PT.oneOfType([PT.string, PT.arrayOf(PT.string)]),
 
-        /** True (default) to allow selection of more than one file. */
+        /** True (default) to allow multiple files in a single upload. */
         enableMulti: PT.bool,
 
         /**

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -104,7 +104,23 @@ export class FileChooser extends Component {
                             )
                         });
                     },
-                    onDrop: (accepted, rejected) => this.model.onDrop(accepted, rejected)
+                    onDrop: (accepted, rejected) => {
+
+
+                        // YANAS PLAYGROUND
+                        console.log('these were accepted: ', accepted);
+                        console.log('these were rejected: ', rejected);
+                        console.log('this is the model: ', this.model);
+                        console.log('this is the status of multi: ', enableMulti);
+                        console.log('modesl files: ', this.model.files);
+                        console.log('models files length: ', this.model.files.length);
+
+                        if (enableMulti || !enableMulti && this.model.files.length === 0) {
+                            this.model.onDrop(accepted, rejected);
+                        }
+
+
+                    }
                 }),
                 grid({
                     model: gridModel,

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -115,11 +115,7 @@ export class FileChooser extends Component {
                         console.log('modesl files: ', this.model.files);
                         console.log('models files length: ', this.model.files.length);
 
-                        if (enableMulti || !enableMulti && this.model.files.length === 0) {
-                            this.model.onDrop(accepted, rejected);
-                        }
-
-
+                        this.model.onDrop(accepted, rejected, enableMulti);
                     }
                 }),
                 grid({

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -46,7 +46,7 @@ export class FileChooser extends Component {
         /**
          * True to allow user to drop multiple files into the dropzone at once.  True also allows for selection of
          * multiple files within the OS pop-up window.  Defaults to enableMulti. */
-        enableDropMulti: PT.bool,
+        enableAddMulti: PT.bool,
 
         /** Maximum accepted file size in bytes. */
         maxSize: PT.number,
@@ -76,16 +76,16 @@ export class FileChooser extends Component {
             {gridModel, lastRejectedCount} = model,
             {accept, maxSize, minSize} = props,
             enableMulti = withDefault(props.enableMulti, true),
-            enableDropMulti = withDefault(props.enableDropMulti, enableMulti),
+            enableAddMulti = withDefault(props.enableAddMulti, enableMulti),
             showFileGrid = withDefault(props.showFileGrid, true);
 
         return hbox({
             items: [
                 dropzone({
-                    accept: accept,
-                    maxSize: maxSize,
-                    minSize: minSize,
-                    multiple: enableDropMulti,
+                    accept,
+                    maxSize,
+                    minSize,
+                    multiple: enableAddMulti,
                     item: ({getRootProps, getInputProps, isDragActive, draggedFiles}) => {
                         const draggedCount = draggedFiles.length,
                             targetText = isDragActive ?

--- a/desktop/cmp/filechooser/FileChooser.js
+++ b/desktop/cmp/filechooser/FileChooser.js
@@ -43,6 +43,11 @@ export class FileChooser extends Component {
         /** True (default) to allow selection of more than one file. */
         enableMulti: PT.bool,
 
+        /**
+         * True to allow user to drop multiple files into the dropzone at once.  True also allows for selection of
+         * multiple files within the OS pop-up window.  Defaults to enableMulti. */
+        enableDropMulti: PT.bool,
+
         /** Maximum accepted file size in bytes. */
         maxSize: PT.number,
 
@@ -69,16 +74,18 @@ export class FileChooser extends Component {
     render() {
         const {model, props, fileNoun} = this,
             {gridModel, lastRejectedCount} = model,
+            {accept, maxSize, minSize} = props,
             enableMulti = withDefault(props.enableMulti, true),
+            enableDropMulti = withDefault(props.enableDropMulti, enableMulti),
             showFileGrid = withDefault(props.showFileGrid, true);
 
         return hbox({
             items: [
                 dropzone({
-                    accept: props.accept,
-                    maxSize: props.maxSize,
-                    minSize: props.minSize,
-                    multiple: enableMulti,
+                    accept: accept,
+                    maxSize: maxSize,
+                    minSize: minSize,
+                    multiple: enableDropMulti,
                     item: ({getRootProps, getInputProps, isDragActive, draggedFiles}) => {
                         const draggedCount = draggedFiles.length,
                             targetText = isDragActive ?
@@ -105,15 +112,6 @@ export class FileChooser extends Component {
                         });
                     },
                     onDrop: (accepted, rejected) => {
-
-
-                        // YANAS PLAYGROUND
-                        console.log('these were accepted: ', accepted);
-                        console.log('these were rejected: ', rejected);
-                        console.log('this is the model: ', this.model);
-                        console.log('this is the status of multi: ', enableMulti);
-                        console.log('modesl files: ', this.model.files);
-                        console.log('models files length: ', this.model.files.length);
 
                         this.model.onDrop(accepted, rejected, enableMulti);
                     }

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -98,7 +98,6 @@ export class FileChooserModel {
         if (accepted.length) {
             this.addFiles(accepted);
         }
-
         this.setLastRejectedCount(rejected.length);
     }
 

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -95,6 +95,8 @@ export class FileChooserModel {
     // Implementation
     //------------------------
     onDrop(accepted, rejected, enableMulti) {
+        console.log('accepted: ', accepted)
+        console.log('rejected: ', rejected)
         if (accepted.length) {
             if (!enableMulti && this.files.length !== 0) this.removeAllFiles();
             this.addFiles(accepted);

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -102,13 +102,6 @@ export class FileChooserModel {
     //------------------------
     onDrop(accepted, rejected, enableMulti) {
         if (!isEmpty(accepted)) {
-            // if (!enableMulti && !isEmpty(this.files)) this.removeAllFiles();
-            // if (!enableMulti && accepted.length > 1) {
-            //     this.addFiles((accepted[0]));
-            // } else {
-            //     this.addFiles(accepted);
-            // }
-
             if (!enableMulti) {
                 this.setSingleFile(accepted[0]);
             } else {

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -95,15 +95,9 @@ export class FileChooserModel {
     // Implementation
     //------------------------
     onDrop(accepted, rejected, enableMulti) {
-        const {files} = this;
-
         if (accepted.length) {
-            if (enableMulti || !enableMulti && files.length === 0) {
-                this.addFiles(accepted);
-            } else if (!enableMulti && files.length > 0) {
-                this.removeAllFiles();
-                this.addFiles(accepted);
-            }
+            if (!enableMulti && this.files.length !== 0) this.removeAllFiles();
+            this.addFiles(accepted);
         }
         this.setLastRejectedCount(rejected.length);
     }

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -75,6 +75,11 @@ export class FileChooserModel {
         ], 'name');
     }
 
+    @action
+    setSingleFile(file) {
+        this.files = [file];
+    }
+
     /**
      * Remove a single file from the current selection.
      * @param {String} name - name of the file to remove.
@@ -97,8 +102,18 @@ export class FileChooserModel {
     //------------------------
     onDrop(accepted, rejected, enableMulti) {
         if (!isEmpty(accepted)) {
-            if (!enableMulti && !isEmpty(this.files)) this.removeAllFiles();
-            this.addFiles(accepted);
+            // if (!enableMulti && !isEmpty(this.files)) this.removeAllFiles();
+            // if (!enableMulti && accepted.length > 1) {
+            //     this.addFiles((accepted[0]));
+            // } else {
+            //     this.addFiles(accepted);
+            // }
+
+            if (!enableMulti) {
+                this.setSingleFile(accepted[0]);
+            } else {
+                this.addFiles(accepted);
+            }
         }
         this.setLastRejectedCount(rejected.length);
     }

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -11,6 +11,7 @@ import {fileExtCol, GridModel} from '@xh/hoist/cmp/grid';
 import {actionCol, calcActionColWidth} from '@xh/hoist/desktop/cmp/grid';
 import {find, last, without, uniqBy} from 'lodash';
 import filesize from 'filesize';
+import {isEmpty} from 'codemirror/src/util/misc';
 
 
 @HoistModel
@@ -95,10 +96,8 @@ export class FileChooserModel {
     // Implementation
     //------------------------
     onDrop(accepted, rejected, enableMulti) {
-        console.log('accepted: ', accepted)
-        console.log('rejected: ', rejected)
-        if (accepted.length) {
-            if (!enableMulti && this.files.length !== 0) this.removeAllFiles();
+        if (!isEmpty(accepted)) {
+            if (!enableMulti && !isEmpty(this.files)) this.removeAllFiles();
             this.addFiles(accepted);
         }
         this.setLastRejectedCount(rejected.length);

--- a/desktop/cmp/filechooser/FileChooserModel.js
+++ b/desktop/cmp/filechooser/FileChooserModel.js
@@ -94,9 +94,16 @@ export class FileChooserModel {
     //------------------------
     // Implementation
     //------------------------
-    onDrop(accepted, rejected) {
+    onDrop(accepted, rejected, enableMulti) {
+        const {files} = this;
+
         if (accepted.length) {
-            this.addFiles(accepted);
+            if (enableMulti || !enableMulti && files.length === 0) {
+                this.addFiles(accepted);
+            } else if (!enableMulti && files.length > 0) {
+                this.removeAllFiles();
+                this.addFiles(accepted);
+            }
         }
         this.setLastRejectedCount(rejected.length);
     }


### PR DESCRIPTION
`enableMulti` config now toggles to accept multiple files in a single upload:

+ behavior of prev. `enableMulti` is now delegated to `enableDropMulti` config
+ `enableDropMulti` configs dropzone to accept multiple files; it also enables the OS file picker pop-up window to pick multiple files
+ minor code tweak: destructed some configs from `props`

