### PR TITLE
Grid Summary Row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
 
+## v24.0.0-SNAPSHOT - UNDER DEVELOPMENT
+### 🎁 New Features
+* `Store` now provides a `summaryRecord` property which can be used to expose aggregated data for the data it contains.
+    The raw data for this record can be provided to `loadData() and updataData()` either via an explicit argument to 
+    these methods, or as the root node of the raw data provided (see `loadRootAsSummary`).
+* `GridModel` now supports a `showSummary` property which can be used to display its store's summaryRecord as either 
+    a pinned top or bottom row.
+
 ## v23.0.0 - 2019-05-30 
 
 ### 🎁 New Features

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -506,8 +506,6 @@ export class Grid extends Component {
         }
     }
 
-    // Updates pinned top and bottom row data based on the model/store configuration and presence of
-    // a summary record in the store
     updatePinnedRowData() {
         const {model} = this,
             {store, showSummary} = model,

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -351,7 +351,7 @@ export class Grid extends Component {
 
                         // Load updated data into the grid.
                         api.setRowData(records);
-                        this.updatePinnedRowData(records);
+                        this.updatePinnedRowData();
 
                         // Size columns to account for scrollbar show/hide due to row count change.
                         api.sizeColumnsToFit();
@@ -506,12 +506,6 @@ export class Grid extends Component {
         }
     }
 
-    // Checks whether there should be a summary pinned row in the grid
-    haveSummaryRow() {
-        const {store, showSummary} = this.model;
-        return showSummary && store.summaryRecord;
-    }
-
     // Updates pinned top and bottom row data based on the model/store configuration and presence of
     // a summary record in the store
     updatePinnedRowData() {
@@ -521,8 +515,8 @@ export class Grid extends Component {
             pinnedTopRecords = [],
             pinnedBottomRecords = [];
 
-        if (this.haveSummaryRow()) {
-            const arr = showSummary === 'top' ? pinnedTopRecords : pinnedBottomRecords;
+        if (showSummary && store.summaryRecord) {
+            const arr = (showSummary === 'bottom') ? pinnedBottomRecords : pinnedTopRecords;
             arr.push(store.summaryRecord);
         }
 

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -78,8 +78,6 @@ export class GridModel {
     enableExport;
     /** @member {object} */
     exportOptions;
-    /** @member {string|boolean} */
-    rootSummary;
 
     /** @member {AgGridModel} */
     @managed agGridModel;
@@ -95,6 +93,8 @@ export class GridModel {
     @observable.ref sortBy = [];
     /** @member {string[]} */
     @observable groupBy = null;
+    /** @member {string|boolean} */
+    @observable showSummary = false;
 
     static defaultContextMenuTokens = [
         'copy',
@@ -114,8 +114,9 @@ export class GridModel {
      * @param {(Store|Object)} [c.store] - a Store instance, or a config with which to create a
      *      Store. If not supplied, store fields will be inferred from columns config.
      * @param {boolean} [c.treeMode] - true if grid is a tree grid (default false).
-     * @param {string|boolean} [c.rootSummary] - location for a root summary / total row.
-     *      Valid values are true/'top', 'bottom', or false (default false)
+     * @param {string|boolean} [c.showSummary] - location for a summary / total row. Requires that
+     *      a summary Records exists in the store.
+     *      Valid values are true/'top', 'bottom', or false (default false).
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` with which to create one.
      * @param {(Object|string)} [c.stateModel] - config or string `gridId` for a GridStateModel.
@@ -146,7 +147,7 @@ export class GridModel {
         store,
         columns,
         treeMode = false,
-        rootSummary = false,
+        showSummary = false,
         selModel,
         stateModel = null,
         emptyText = null,
@@ -168,7 +169,8 @@ export class GridModel {
         ...rest
     }) {
         this.treeMode = treeMode;
-        this.rootSummary = (rootSummary === true) ? 'top' : rootSummary;
+        this.setShowSummary(showSummary);
+
         this.emptyText = emptyText;
         this.rowClassFn = rowClassFn;
         this.groupSortFn = withDefault(groupSortFn, this.defaultGroupSortFn);
@@ -385,6 +387,14 @@ export class GridModel {
         this.columns = columns;
         this.columnState = this.getLeafColumns()
             .map(({colId, width, hidden}) => ({colId, width, hidden}));
+    }
+
+    /**
+     * @param {string|boolean} showSummary - location for a summary row
+     */
+    @action
+    setShowSummary(showSummary) {
+        this.showSummary = (showSummary === true) ? 'top' : showSummary;
     }
 
     showColChooser() {

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -78,6 +78,8 @@ export class GridModel {
     enableExport;
     /** @member {object} */
     exportOptions;
+    /** @member {string|boolean} */
+    rootSummary;
 
     /** @member {AgGridModel} */
     @managed agGridModel;
@@ -112,6 +114,8 @@ export class GridModel {
      * @param {(Store|Object)} [c.store] - a Store instance, or a config with which to create a
      *      Store. If not supplied, store fields will be inferred from columns config.
      * @param {boolean} [c.treeMode] - true if grid is a tree grid (default false).
+     * @param {string|boolean} [c.rootSummary] - location for a root summary / total row.
+     *      Valid values are true/'top', 'bottom', or false (default false)
      * @param {(StoreSelectionModel|Object|String)} [c.selModel] - StoreSelectionModel, or a
      *      config or string `mode` with which to create one.
      * @param {(Object|string)} [c.stateModel] - config or string `gridId` for a GridStateModel.
@@ -142,6 +146,7 @@ export class GridModel {
         store,
         columns,
         treeMode = false,
+        rootSummary = false,
         selModel,
         stateModel = null,
         emptyText = null,
@@ -163,6 +168,7 @@ export class GridModel {
         ...rest
     }) {
         this.treeMode = treeMode;
+        this.rootSummary = (rootSummary === true) ? 'top' : rootSummary;
         this.emptyText = emptyText;
         this.rowClassFn = rowClassFn;
         this.groupSortFn = withDefault(groupSortFn, this.defaultGroupSortFn);

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -13,7 +13,7 @@ import {
     StoreContextMenu
 } from '@xh/hoist/dynamics/desktop';
 import {ColChooserModel as MobileColChooserModel} from '@xh/hoist/dynamics/mobile';
-import {action, observable} from '@xh/hoist/mobx';
+import {action, bindable, observable} from '@xh/hoist/mobx';
 import {ensureUnique, throwIf, warnIf, withDefault} from '@xh/hoist/utils/js';
 import {
     castArray,
@@ -94,7 +94,7 @@ export class GridModel {
     /** @member {string[]} */
     @observable groupBy = null;
     /** @member {string|boolean} */
-    @observable showSummary = false;
+    @bindable showSummary = false;
 
     static defaultContextMenuTokens = [
         'copy',
@@ -169,7 +169,7 @@ export class GridModel {
         ...rest
     }) {
         this.treeMode = treeMode;
-        this.setShowSummary(showSummary);
+        this.showSummary = showSummary;
 
         this.emptyText = emptyText;
         this.rowClassFn = rowClassFn;
@@ -387,14 +387,6 @@ export class GridModel {
         this.columns = columns;
         this.columnState = this.getLeafColumns()
             .map(({colId, width, hidden}) => ({colId, width, hidden}));
-    }
-
-    /**
-     * @param {string|boolean} showSummary - location for a summary row
-     */
-    @action
-    setShowSummary(showSummary) {
-        this.showSummary = (showSummary === true) ? 'top' : showSummary;
     }
 
     showColChooser() {

--- a/data/Record.js
+++ b/data/Record.js
@@ -4,7 +4,7 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {isEqual, isNil, isString} from 'lodash';
+import {isEqual, isNil} from 'lodash';
 import {throwIf} from '@xh/hoist/utils/js';
 
 /**
@@ -53,7 +53,7 @@ export class Record {
     }
 
     get isSummary() {
-        return this.id === 'summary';
+        return this === this.store.summaryRecord;
     }
 
     /**
@@ -75,8 +75,7 @@ export class Record {
      * @param {Record} [c.parent] - parent record, if any.
      */
     constructor({data, raw, store, parent}) {
-        const {idSpec} = store,
-            id = isString(idSpec) ? data[idSpec] : idSpec(data);
+        const id = store.buildRecordId(data);
 
         throwIf(isNil(id), "Record has an undefined ID. Use 'Store.idSpec' to resolve a unique ID for each record.");
 

--- a/data/Record.js
+++ b/data/Record.js
@@ -52,6 +52,9 @@ export class Record {
         return this.store.getChildrenById(this.id, false);
     }
 
+    get isSummary() {
+        return this.id === 'summary';
+    }
 
     /**
      * Construct a Record from a raw source object. Extract values from the source object for all

--- a/data/Store.js
+++ b/data/Store.js
@@ -127,7 +127,7 @@ export class Store {
 
         const oldSummary = this.summaryRecord,
             newSummary = this.getRootSummary(rawData);
-        if (oldSummary && newSummary && summaryRecord.id === this.buildRecordId(newSummary)) {
+        if (oldSummary && newSummary && oldSummary.id === this.buildRecordId(newSummary)) {
             rawData = newSummary.children;
             rawSummaryData = {...newSummary, children: null};
         }

--- a/data/Store.js
+++ b/data/Store.js
@@ -171,6 +171,10 @@ export class Store {
         return this._all.rootList;
     }
 
+    get summaryRecord() {
+        return this._all.summaryRecord;
+    }
+
     /** Filter function to be applied. */
     get filter() {return this._filter}
     setFilter(filterFn) {

--- a/data/Store.js
+++ b/data/Store.js
@@ -171,6 +171,9 @@ export class Store {
         return this._all.rootList;
     }
 
+    /**
+     * @returns {Record|null} - the summary record, or null if no summary records exists in this store
+     */
     get summaryRecord() {
         return this._all.summaryRecord;
     }

--- a/data/cube/impl/QueryExecutor.js
+++ b/data/cube/impl/QueryExecutor.js
@@ -4,11 +4,7 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {
-    Cube,
-    AggregateCubeRecord,
-    ValueFilter
-} from '@xh/hoist/data/cube';
+import {Cube, AggregateCubeRecord, ValueFilter} from '@xh/hoist/data/cube';
 import {isEmpty, groupBy, clone, map} from 'lodash';
 import {wait} from '@xh/hoist/promise';
 
@@ -20,7 +16,7 @@ export class QueryExecutor {
     static async getDataAsync(query) {
         const {dimensions, includeRoot, fields, cube, filters} = query,
             cubeRecords = cube.records,
-            rootId = query.filtersAsString();
+            rootId = 'summary';
 
         const leaves = !isEmpty(filters) ?
             cubeRecords.filter(rec => filters.every(f => f.matches(rec))) :

--- a/data/cube/impl/QueryExecutor.js
+++ b/data/cube/impl/QueryExecutor.js
@@ -16,7 +16,7 @@ export class QueryExecutor {
     static async getDataAsync(query) {
         const {dimensions, includeRoot, fields, cube, filters} = query,
             cubeRecords = cube.records,
-            rootId = 'summary';
+            rootId = 'root';
 
         const leaves = !isEmpty(filters) ?
             cubeRecords.filter(rec => filters.every(f => f.matches(rec))) :

--- a/data/cube/impl/QueryExecutor.js
+++ b/data/cube/impl/QueryExecutor.js
@@ -4,7 +4,11 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {Cube, AggregateCubeRecord, ValueFilter} from '@xh/hoist/data/cube';
+import {
+    Cube,
+    AggregateCubeRecord,
+    ValueFilter
+} from '@xh/hoist/data/cube';
 import {isEmpty, groupBy, clone, map} from 'lodash';
 import {wait} from '@xh/hoist/promise';
 
@@ -16,7 +20,7 @@ export class QueryExecutor {
     static async getDataAsync(query) {
         const {dimensions, includeRoot, fields, cube, filters} = query,
             cubeRecords = cube.records,
-            rootId = 'root';
+            rootId = query.filtersAsString();
 
         const leaves = !isEmpty(filters) ?
             cubeRecords.filter(rec => filters.every(f => f.matches(rec))) :

--- a/desktop/cmp/grid/columns/Actions.js
+++ b/desktop/cmp/grid/columns/Actions.js
@@ -45,7 +45,7 @@ export const actionCol = {
     chooserName: 'Actions',
     excludeFromExport: true,
     renderer: (value, {record, column, agParams}) => {
-        if (agParams.node.group) return null;
+        if (agParams.node.group || (record && record.isSummary)) return null;
 
         const {actions, actionsShowOnHoverOnly, gridModel} = column;
         if (isEmpty(actions)) return null;


### PR DESCRIPTION
#737 

Support for showing a summary/total row in our Grid component pinned to the top or bottom (uses ag-Grid pinned row feature)

In order to use the summary row the application needs to include a row in the store with an id of "summary" which contains the data to display, and set the new `showSummary` prop on the GridModel. If the store contains hierarchical data, the "summary" record will be excluded from the main record hierarchy (it is stored separately in RecordSet). I went through several iterations on this implementation and landed on this as the best approach. In the future if we end up merging the Aggregation support in Cube/CubeRecord over to Store/Record the interface for the summary support shouldn't need to change and would be able to handle summary record without needing the application to provide the it.

A caveat of using the summary row is that any app-defined pinned rows will be overwritten when the Grid component updates the summary row. An alternative approach to achieving summary rows in ag-Grid would be to use aligned grids, but that seemed like it would be a more complex implementation for our Grid/GridModel, though it has the advantage of not conflicting with pinned rows an application may want to set.