### PR TITLE
Grid/Store Selection Optimizations

### DIFF
--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -364,7 +364,7 @@ export class Grid extends Component {
 
                     // Set flag if data is hierarchical.
                     this._isHierarchical = store.allRootCount != store.allCount;
-                  
+
                     // Increment version counter to trigger selectionReaction w/latest data.
                     this._dataVersion++;
                 });
@@ -512,8 +512,8 @@ export class Grid extends Component {
         return data.xhTreePath;
     };
 
-    onSelectionChanged = (ev) => {
-        this.model.selModel.select(ev.api.getSelectedRows());
+    onSelectionChanged = () => {
+        this.model.noteAgSelectionStateChanged();
     };
 
     // Catches column re-ordering AND resizing via user drag-and-drop interaction.

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -409,6 +409,9 @@ export class GridModel {
         this.applyColumnStateChanges(colStateChanges);
     }
 
+
+    // We debounce this method because ag-Grid will fire the selection changed event for each node
+    // that is being selected
     @debounced(0)
     noteAgSelectionStateChanged() {
         const {selModel, agGridModel} = this;

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -409,13 +409,9 @@ export class GridModel {
         this.applyColumnStateChanges(colStateChanges);
     }
 
-    /**
-     * Sync selectionModel state from the grid's current selection.
-     *
-     * We debounce this method because the implementation of `AgGridModel.setSelectedRowNodeIds()`
-     * selects nodes one-by-one, and ag-Grid will fire a selection changed event for each iteration.
-     * This avoids a storm of events looping through the reaction when selecting in bulk.
-     */
+    // We debounce this method because the implementation of `AgGridModel.setSelectedRowNodeIds()`
+    // selects nodes one-by-one, and ag-Grid will fire a selection changed event for each iteration.
+    // This avoids a storm of events looping through the reaction when selecting in bulk.
     @debounced(0)
     noteAgSelectionStateChanged() {
         const {selModel, agGridModel} = this;

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -37,6 +37,7 @@ import {
 import {GridStateModel} from './GridStateModel';
 import {GridSorter} from './impl/GridSorter';
 import {managed} from '../../core/mixins';
+import {debounced} from '../../utils/js';
 
 /**
  * Core Model for a Grid, specifying the grid's data store, column definitions,
@@ -406,6 +407,12 @@ export class GridModel {
 
         pull(colStateChanges, null);
         this.applyColumnStateChanges(colStateChanges);
+    }
+
+    @debounced(0)
+    noteAgSelectionStateChanged() {
+        const {selModel, agGridModel} = this;
+        selModel.select(agGridModel.getSelectedRowNodeIds());
     }
 
     /**

--- a/cmp/grid/GridModel.js
+++ b/cmp/grid/GridModel.js
@@ -409,9 +409,13 @@ export class GridModel {
         this.applyColumnStateChanges(colStateChanges);
     }
 
-
-    // We debounce this method because ag-Grid will fire the selection changed event for each node
-    // that is being selected
+    /**
+     * Sync selectionModel state from the grid's current selection.
+     *
+     * We debounce this method because the implementation of `AgGridModel.setSelectedRowNodeIds()`
+     * selects nodes one-by-one, and ag-Grid will fire a selection changed event for each iteration.
+     * This avoids a storm of events looping through the reaction when selecting in bulk.
+     */
     @debounced(0)
     noteAgSelectionStateChanged() {
         const {selModel, agGridModel} = this;

--- a/data/StoreSelectionModel.js
+++ b/data/StoreSelectionModel.js
@@ -77,7 +77,6 @@ export class StoreSelectionModel {
             return this.store.getById(id, true);
         });
 
-        // Avoid trigger selection reactions unnecessarily by making sure the selected ids have actually changed
         if (isEqual(ids, this.ids)) {
             return;
         }

--- a/data/StoreSelectionModel.js
+++ b/data/StoreSelectionModel.js
@@ -7,7 +7,7 @@
 
 import {HoistModel} from '@xh/hoist/core';
 import {action, observable, computed} from '@xh/hoist/mobx';
-import {castArray, intersection, union} from 'lodash';
+import {castArray, intersection, union, isEqual} from 'lodash';
 
 /**
  * Model for managing store selections.
@@ -67,7 +67,7 @@ export class StoreSelectionModel {
     @action
     select(records, clearSelection = true) {
         records = castArray(records);
-        if (this.mode == 'disabled')  return;
+        if (this.mode == 'disabled') return;
         if (this.mode == 'single' && records.length > 1) {
             records = [records[0]];
         }
@@ -76,6 +76,12 @@ export class StoreSelectionModel {
         }).filter(id => {
             return this.store.getById(id, true);
         });
+
+        // Avoid trigger selection reactions unnecessarily by making sure the selected ids have actually changed
+        if (isEqual(ids, this.ids)) {
+            return;
+        }
+
         this.ids = clearSelection ? ids : union(this.ids, ids);
     }
 
@@ -84,7 +90,6 @@ export class StoreSelectionModel {
     clear() {
         this.select([]);
     }
-
 
     //------------------------
     // Implementation


### PR DESCRIPTION
Fixes #1150 

The cause of the poor performance when programmatically selecting several records was that the ag-Grid onSelectionChanged event was being fired for each call we make to `node.setSelected(true)` (on the subsequent frame). This results in the Grid updating the selection model based on the current ag-Grid selection state, which would then trigger another selectionReaction in the grid, etc. So if you are selecting 1000 rows programmatically you would end up with 1000 extra updates of the observable.ref `ids` property of StoreSelectionModel, and 1000 extra calls to the Grid selectionReaction. The selectionReaction would be a no-op because we do check that before updating the ag-Grid state, but we did not have a similar check on the other end before we update our selection model state, and the cost of updating the observable prop and triggering the reaction was causing the very noticeable slow-down.

ag-Grid does not appear to have any kind of `setSelectedRows` method on it's api which would result in the single selection changed event, so it is necessary for us to handle it in our logic.

I made 2 changes to optimize our handling of updating the selection model state. Either would serve to address this specific issue, but I felt both were appropriate changes to make.

1. Debounce (until the next frame) updating of the selection model state when the ag-Grid onSelectionChanged event is fired. This is something we might want to consider doing for every ag-Grid event handler since we always use those events to trigger a full sync of our model with the ag-Grid state, and it is not clear if they may be fired multiple times per change if some kind of bulk operation was performed (such as hiding multiple columns, etc.)
2. Only update the ids prop in StoreSelectionModel if the ids have actually changed. I think this is a sensible optimization and a general best-practice when updating observable.ref properties to avoid triggering reactions unnecessarily.