### PR TITLE
Mobile Panel uses mobile mask.

### DIFF
--- a/mobile/cmp/panel/Panel.js
+++ b/mobile/cmp/panel/Panel.js
@@ -10,7 +10,7 @@ import {castArray, omitBy} from 'lodash';
 import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {vbox, vframe} from '@xh/hoist/cmp/layout';
 import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
-import {mask} from '@xh/hoist/desktop/cmp/mask';
+import {mask} from '@xh/hoist/mobile/cmp/mask';
 import {isReactElement} from '@xh/hoist/utils/react';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {panelHeader} from './impl/PanelHeader';


### PR DESCRIPTION
Mobile Panel uses the mobile mask, to avoid inadvertently bringing in components from the desktop framework.