### PR TITLE
tailMode bug fix

### DIFF
--- a/admin/tabs/logging/viewer/LogDisplayModel.js
+++ b/admin/tabs/logging/viewer/LogDisplayModel.js
@@ -72,7 +72,7 @@ export class LogDisplayModel {
             })
             .then(response => {
                 if (!response.success) throw new Error(response.exception);
-                this.setRows(this.startLine ? response.content : response.content.reverse());
+                this.setRows(parent.startLine ? response.content : response.content.reverse());
             })
             .catch(e => {
                 // Show errors inline in the viewer vs. a modal alert or catchDefault().


### PR DESCRIPTION
Fixes issue #1166: replace `this.startLine` with `parent.startLine` +

* It seems that the server returns an array that depends param `parent.startLine`, but then the client conditionally `.reverse()` the response.  Maybe we can consider removing the work from the client and instead having the server return the array in appropriate order to begin with?   (Yana is unsure whether there are other pieces that depend on that endpoint returning the way it currently does)

