### PR TITLE
On mobile, force overflow hidden on the floating top and bottom containers (Fixes #1179)

### DIFF
--- a/cmp/ag-grid/AgGrid.scss
+++ b/cmp/ag-grid/AgGrid.scss
@@ -5,6 +5,15 @@
   height: auto !important;
 }
 
+.xh-mobile {
+  // ag-grid adds these when the center viewport has overflow, so that the space taken by the scrollbar is consistent in
+  // the top and bottom floating divs. On mobile we do not render scrollbars for the center viewport, so force hiding
+  // in the top and bottom floating divs.
+  .ag-floating-top, .ag-floating-bottom {
+    overflow-y: hidden !important;
+  }
+}
+
 // Ag-Grid themes referenced here to help ensure a high enough level of specificity for our rules.
 .ag-theme-balham.xh-ag-grid, .ag-theme-balham-dark.xh-ag-grid {
   font-family: var(--xh-grid-font-family);


### PR DESCRIPTION
ag-grid explicitly sets the overflow to either `scroll` or `hidden` on the floating top and bottom containers based on whether the center viewport has overflow in order to keep the space taken by the scrollbar consistent in all containers. 

https://github.com/ag-grid/ag-grid/blob/fe50182e5542b4616d2ef41a03a38836a83daeae/packages/ag-grid-community/src/ts/gridPanel/gridPanel.ts#L884

I think this change is safe since we don't expect to see any scrollbars in the grid on mobile, so ag-grid forcing them on actually makes the containers unbalanced.

Note that this issue does not appear be happen on an actual mobile device.
