### PR TITLE
Handle updating hierarchical data in Store

### DIFF
--- a/data/Record.js
+++ b/data/Record.js
@@ -31,6 +31,7 @@ export class Record {
         return this.parentId != null ? this.store.getById(this.parentId) : null;
     }
 
+    /** @param {Record} parent */
     set parent(parent) {
         this.parentId = parent ? parent.id : null;
         this.xhTreePath = parent ? [...parent.xhTreePath, this.id] : [this.id];

--- a/data/Record.js
+++ b/data/Record.js
@@ -31,6 +31,11 @@ export class Record {
         return this.parentId != null ? this.store.getById(this.parentId) : null;
     }
 
+    set parent(parent) {
+        this.parentId = parent ? parent.id : null;
+        this.xhTreePath = parent ? [...parent.xhTreePath, this.id] : [this.id];
+    }
+
     /** @member {Field[]} */
     get fields() {
         return this.store.fields;
@@ -82,8 +87,7 @@ export class Record {
         this.id = id;
         this.store = store;
         this.raw = raw;
-        this.parentId = parent ? parent.id : null;
-        this.xhTreePath = parent ? [...parent.xhTreePath, id] : [id];
+        this.parent = parent;
 
         store.fields.forEach(f => {
             const {name} = f;

--- a/data/Store.js
+++ b/data/Store.js
@@ -143,6 +143,13 @@ export class Store {
         this.lastUpdated = Date.now();
     }
 
+    @action
+    addData(rawData, parentRecord) {
+        this._all = this._all.addData(rawData, parentRecord ? parentRecord.id : null);
+        this.rebuildFiltered();
+        this.lastUpdated = Date.now();
+    }
+
     /** Remove all records from the store. */
     clear() {
         this.loadData([], null);

--- a/data/Store.js
+++ b/data/Store.js
@@ -111,8 +111,11 @@ export class Store {
     }
 
     /**
-     * Add or update data in store. Existing records not matched by ID to rows in the update
-     * dataset will be left in place.
+     * Add or update data in store. Existing sibling or ancestor records not matched by ID to rows
+     * in the update dataset will be left in place.
+     *
+     * When updating hierarchical data the entire branch will be updated with the provided data. Any
+     * children not included in the data will be removed from the store.
      *
      * Updated summary data can be provided via `rawSummaryData` or as the root data if the Store was
      * created with the loadRootAsSummary flag set to true.
@@ -143,6 +146,12 @@ export class Store {
         this.lastUpdated = Date.now();
     }
 
+    /**
+     * Add data to the store.
+     *
+     * @param {Object[]} rawData
+     * @param {Record} parentRecord
+     */
     @action
     addData(rawData, parentRecord) {
         this._all = this._all.addData(rawData, parentRecord ? parentRecord.id : null);

--- a/data/impl/RecordSet.js
+++ b/data/impl/RecordSet.js
@@ -134,8 +134,15 @@ export class RecordSet {
                 newRecord.parent = currRecord.parent;
             }
 
-            const hasChildren = existingRecords.values().find(rec => rec.parentId === currRecord.id);
-            if (!hasChildren) {
+            let hasChildren = false;
+            for (let rec of existingRecords.values()) {
+                if (rec.parentId == currRecord.id) {
+                    hasChildren = true;
+                    break;
+                }
+            }
+
+            if (hasChildren) {
                 const descendantIds = new Set();
                 this.gatherDescendants(currRecord.id, descendantIds);
                 descendantIds.forEach(id => {

--- a/data/impl/RecordSet.js
+++ b/data/impl/RecordSet.js
@@ -6,6 +6,7 @@
  */
 
 import {throwIf} from '../../utils/js';
+import {isEmpty} from 'lodash';
 
 /**
  * Internal container for Record management within a Store.
@@ -122,45 +123,58 @@ export class RecordSet {
     }
 
     updateData(rawData) {
-        const newRecords = this.createRecords(rawData),
-            existingRecords = new Map(this.records);
+        const updatedRecords = new Map(),
+            {store, records} = this,
+            updateRoots = [];
 
-        newRecords.forEach((newRecord, id) => {
-            const existingRecord = existingRecords.get(id);
-            if (existingRecord) {
-                // Since the data we are updating may be from the middle of the hierarchy, we need to
-                // make sure that we copy the parent over for any existing records because we only
-                // include child information in raw data
-                newRecord.parent = existingRecord.parent;
+        // 1. When updating we need to first create records for the root data, and make sure we carry
+        //    the parent record forward if this new data matches an existing record. Then we can build
+        //    the descendent records with the confidence that their parent and tree paths will be correct
+        rawData.forEach(data => {
+            const rec = store.createRecord(data),
+                existingRecord = records.get(rec.id);
 
-                // When updating an existing record we also always update it's children, so we need
-                // to determine if the existing record has children. Avoiding calling Record.children
-                // here so we don't build the children map unnecessarily.
-                let hasChildren = false;
-                for (let rec of existingRecords.values()) {
-                    if (rec.parentId == existingRecord.id) {
-                        hasChildren = true;
-                        break;
-                    }
-                }
+            // Since our raw data does not include parent information, only children, we need to
+            // make sure that we copy the parent over from the existing record when updating
+            if (existingRecord) rec.parent = existingRecord.parent;
 
-                // Any descendants of the existing record which are no longer descendants of the new
-                // record need to be removed
-                if (hasChildren) {
-                    const descendantIds = new Set();
-                    this.gatherDescendants(existingRecord.id, descendantIds);
-                    descendantIds.forEach(id => {
-                        if (!newRecords.has(id)) existingRecords.delete(id);
-                    });
-                }
-            }
-
-            if (!existingRecord || !existingRecord.isEqual(newRecord)) {
-                existingRecords.set(id, newRecord);
+            updatedRecords.set(rec.id, rec);
+            updateRoots.push(rec);
+            if (!isEmpty(data.children)) {
+                data.children.forEach(childData => this.buildRecords(childData, updatedRecords, rec));
             }
         });
 
-        return new RecordSet(this.store, existingRecords);
+        // 2. If this record set contains hierarchical data then we need to figure out which (if any)
+        //    existing records need to be removed from the record set as part of this update operation
+        const recordIdsToRemove = new Set(),
+            {childrenMap} = this;
+
+        if (childrenMap.size) {
+            updateRoots.forEach(rec => {
+                // When the existing record has descendents which are not part of the updated data
+                // they need to be removed from the record set
+                if (childrenMap.has(rec.id)) {
+                    const descendantIds = this.gatherDescendants(rec.id);
+                    descendantIds.forEach(id => {
+                        if (!updatedRecords.has(id)) recordIdsToRemove.add(id);
+                    });
+                }
+            });
+        }
+
+        // 3. Build the new map of records
+        const newRecords = new Map(records);
+        updatedRecords.forEach((record, id) => {
+            const currRecord = records.get(id);
+            if (!currRecord || !currRecord.isEqual(record)) {
+                newRecords.set(id, record);
+            }
+        });
+
+        recordIdsToRemove.forEach(id => newRecords.delete(id));
+
+        return new RecordSet(store, newRecords);
     }
 
     addData(rawData, parentId) {
@@ -230,7 +244,7 @@ export class RecordSet {
         return ret;
     }
 
-    gatherDescendants(id, idSet) {
+    gatherDescendants(id, idSet = new Set()) {
         if (!idSet.has(id)) {
             idSet.add(id);
             const children = this.childrenMap.get(id);
@@ -238,5 +252,7 @@ export class RecordSet {
                 children.forEach(child => this.gatherDescendants(child.id, idSet));
             }
         }
+
+        return idSet;
     }
 }

--- a/utils/js/LangUtils.js
+++ b/utils/js/LangUtils.js
@@ -10,7 +10,6 @@ import _inflection from 'lodash-inflection';
 
 mixin(_inflection);
 
-
 /**
  * Return the first defined argument - intended to allow for multiple levels of fallback values or
  * expressions when evaluating function parameters or configuration object properties.
@@ -99,7 +98,8 @@ export function warnIf(condition, message) {
  * @param {string} [exceptionMessage] - error to throw if empty.
  */
 export function ensureNotEmpty(obj, exceptionMessage) {
-    exceptionMessage = withDefault(exceptionMessage, 'The provided object or collection cannot be empty.');
+    exceptionMessage = withDefault(exceptionMessage,
+        'The provided object or collection cannot be empty.');
     throwIf(isEmpty(obj), exceptionMessage);
 }
 
@@ -110,7 +110,8 @@ export function ensureNotEmpty(obj, exceptionMessage) {
  * @param {string} [exceptionMessage] - error to throw if non-unique values found.
  */
 export function ensureUnique(arr, exceptionMessage) {
-    exceptionMessage = withDefault(exceptionMessage, 'All items in the provided array must be unique.');
+    exceptionMessage = withDefault(exceptionMessage,
+        'All items in the provided array must be unique.');
     throwIf(arr.length != uniq(arr).length, exceptionMessage);
 }
 
@@ -122,7 +123,8 @@ export function ensureUnique(arr, exceptionMessage) {
  * @param {string} [exceptionMessage] - error to throw if non-unique values found.
  */
 export function ensureUniqueBy(arr, uniqueKey, exceptionMessage) {
-    exceptionMessage = withDefault(exceptionMessage, `Multiple items in the provided array have the same ${uniqueKey} - must be unique.`);
+    exceptionMessage = withDefault(exceptionMessage,
+        `Multiple items in the provided array have the same ${uniqueKey} - must be unique.`);
     throwIf(arr.length != uniqBy(arr, uniqueKey).length, exceptionMessage);
 }
 
@@ -144,4 +146,17 @@ export function singularize(string) {
  */
 export function pluralize(string, count, includeCount) {
     return _inflection.pluralize(string, count, includeCount);
+}
+
+/**
+ * Remove when lodash adds Set/Map support
+ * @param {Set|Map} collection
+ * @param {function} fn
+ */
+export function findIn(collection, fn) {
+    for (let it of collection.values()) {
+        if (fn(it)) return it;
+    }
+
+    return null;
 }


### PR DESCRIPTION
Fixes #1193 and #1194 (found while testing these changes)

Modified logic in RecordSet.updateData to properly handle hierarchical data, per proposals in #1193, and added `addData` method to Store and RecordSet