### PR TITLE
Make sure button child is not null before accessing its props (Fixes #1208)

### DIFF
--- a/desktop/cmp/input/ButtonGroupInput.js
+++ b/desktop/cmp/input/ButtonGroupInput.js
@@ -38,6 +38,8 @@ export class ButtonGroupInput extends HoistInput {
         const {children, minimal, disabled, enableClear, ...rest} = this.getNonLayoutProps();
 
         const buttons = castArray(children).map(button => {
+            if (!button) return null;
+
             const {value} = button.props;
 
             throwIf(button.type.name !== 'Button', 'ButtonGroupInput child must be a Button.');


### PR DESCRIPTION
Handle case where the child Buttons could be null.

Searched through all references to `children` in the codebase, didn't see any other places where we are doing anything other than passing the children through to another component, or similarly null-safe operations.

Fixes #1208 