### PR TITLE
Support for enableClear and rightElement props on DateInput (Fixes #1213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## v25.0.0-SNAPSHOT - under development
 
+### 🎁 New Features
+
+* `DateInput.enableClear` prop added to support built-in button to null-out a date input's value.
+
+### ✨ Style
+
+* Panel splitter collapse button more visible in dark theme. CSS vars to customize further fixed.
+
 ### 📚 Libraries
 
 * @blueprintjs/core `3.15 -> 3.16`
@@ -9,6 +17,7 @@
 * codemirror `5.47 -> 5.48`
 * mobx `6.0 -> 6.1`
 
+[Commit Log](https://github.com/exhi/hoist-react/compare/v24.0.0...develop)
 
 ## v24.0.0 - 2019-06-24
 

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -15,7 +15,7 @@ import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {datePicker as bpDatePicker, popover} from '@xh/hoist/kit/blueprint';
 import {div} from '@xh/hoist/cmp/layout';
 import {textInput} from '@xh/hoist/desktop/cmp/input';
-import {button} from '@xh/hoist/desktop/cmp/button';
+import {button, buttonGroup} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {Ref} from '@xh/hoist/utils/react';
 import {withDefault} from '@xh/hoist/utils/js';
@@ -44,6 +44,9 @@ export class DateInput extends HoistInput {
         /** Enable using the DatePicker popover */
         enablePicker: PT.bool,
 
+        /** True to show a "clear" button aligned to the right of the control. default false */
+        enableClear: PT.bool,
+
         /**
          * MomentJS format string for date display and parsing. Defaults to `YYYY-MM-DD HH:mm:ss`,
          * with default presence of time components determined by the timePrecision prop.
@@ -52,6 +55,9 @@ export class DateInput extends HoistInput {
 
         /** Icon to display inline on the left side of the input. */
         leftIcon: PT.element,
+
+        /** Element to display inline on the right side of the input. */
+        rightElement: PT.element,
 
         /** Maximum (inclusive) valid date. */
         maxDate: PT.instanceOf(Date),
@@ -102,7 +108,9 @@ export class DateInput extends HoistInput {
     render() {
         const props = this.getNonLayoutProps(),
             layoutProps = this.getLayoutProps(),
-            enablePicker = withDefault(props.enablePicker, true);
+            enablePicker = withDefault(props.enablePicker, true),
+            enableClear = withDefault(props.enableClear, false),
+            rightElement = withDefault(props.rightElement, this.renderButtons(enableClear, enablePicker));
 
         return div({
             item: popover({
@@ -133,12 +141,7 @@ export class DateInput extends HoistInput {
                     value: this.formatDate(this.renderValue),
                     className: this.getClassName(),
                     onCommit: this.onInputCommit,
-                    rightElement: button({
-                        omit: !enablePicker,
-                        icon: Icon.calendar(),
-                        tabIndex: -1, // Prevent focus on tab
-                        onClick: this.onPopoverBtnClick
-                    }),
+                    rightElement,
 
                     disabled: props.disabled,
                     leftIcon: props.leftIcon,
@@ -153,6 +156,27 @@ export class DateInput extends HoistInput {
             onBlur: this.onBlur,
             onFocus: this.onFocus,
             onKeyDown: this.onKeyDown
+        });
+    }
+
+    renderButtons(enableClear, enablePicker) {
+        if (!enableClear && !enablePicker) return null;
+        return buttonGroup({
+            padding: 0,
+            items: [
+                button({
+                    omit: !enableClear,
+                    icon: Icon.cross(),
+                    tabIndex: -1, // Prevent focus on tab¬
+                    onClick: this.onClearBtnClick
+                }),
+                button({
+                    omit: !enablePicker,
+                    icon: Icon.calendar(),
+                    tabIndex: -1, // Prevent focus on tab
+                    onClick: this.onPopoverBtnClick
+                })
+            ]
         });
     }
 
@@ -185,6 +209,11 @@ export class DateInput extends HoistInput {
         super.noteFocused();
     }
 
+    onClearBtnClick = () => {
+        this.noteValueChange(null);
+        this.doCommit();
+    };
+
     onPopoverBtnClick = () => {
         this.setPopoverOpen(!this.popoverOpen);
     };
@@ -204,7 +233,7 @@ export class DateInput extends HoistInput {
     onPopoverClose = () => {
         this.doCommit();
     };
-    
+
     onInputCommit = (value) => {
         const date = this.parseDate(value);
         this.onDateChange(date);
@@ -227,7 +256,7 @@ export class DateInput extends HoistInput {
         this.setPopoverOpen(false);
     };
 
-    applyPrecision(date)  {
+    applyPrecision(date) {
         let {timePrecision} = this.props;
         date = clone(date);
         if (timePrecision == 'second') {
@@ -262,4 +291,5 @@ export class DateInput extends HoistInput {
         return isNaN(ret) ? null : ret;
     }
 }
+
 export const dateInput = elemFactory(DateInput);

--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -18,7 +18,7 @@ import {textInput} from '@xh/hoist/desktop/cmp/input';
 import {button, buttonGroup} from '@xh/hoist/desktop/cmp/button';
 import {Icon} from '@xh/hoist/icon';
 import {Ref} from '@xh/hoist/utils/react';
-import {withDefault} from '@xh/hoist/utils/js';
+import {warnIf, withDefault} from '@xh/hoist/utils/js';
 import {bindable} from '@xh/hoist/mobx';
 import {HoistInput} from '@xh/hoist/cmp/input';
 
@@ -56,7 +56,10 @@ export class DateInput extends HoistInput {
         /** Icon to display inline on the left side of the input. */
         leftIcon: PT.element,
 
-        /** Element to display inline on the right side of the input. */
+        /**
+         * Element to display inline on the right side of the input. Note if provided, this will
+         * take the place of the (default) calendar-picker button and (optional) clear button.
+         */
         rightElement: PT.element,
 
         /** Maximum (inclusive) valid date. */
@@ -112,6 +115,11 @@ export class DateInput extends HoistInput {
             enableClear = withDefault(props.enableClear, false),
             rightElement = withDefault(props.rightElement, this.renderButtons(enableClear, enablePicker));
 
+        warnIf(
+            (props.enableClear || props.enablePicker) && props.rightElement,
+            'Cannot specify enableClear or enablePicker along with custom rightElement - built-in clear/picker button will not be shown.'
+        );
+
         return div({
             item: popover({
                 isOpen: enablePicker && this.popoverOpen && !this.props.disabled,
@@ -161,13 +169,14 @@ export class DateInput extends HoistInput {
 
     renderButtons(enableClear, enablePicker) {
         if (!enableClear && !enablePicker) return null;
+
         return buttonGroup({
             padding: 0,
             items: [
                 button({
                     omit: !enableClear,
                     icon: Icon.cross(),
-                    tabIndex: -1, // Prevent focus on tab¬
+                    tabIndex: -1, // Prevent focus on tab
                     onClick: this.onClearBtnClick
                 }),
                 button({

--- a/kit/blueprint/styles.scss
+++ b/kit/blueprint/styles.scss
@@ -248,18 +248,33 @@ $pt-transition-duration: 100ms !default;
 }
 
 /* Apply blueprint styling to non-blueprint icons within input groups */
-.bp3-input-group svg:not(.bp3-icon) {
-  position: absolute;
-  top: 0;
-  line-height: 1;
-  font-size: var(--xh-font-size-large-px);
-  font-weight: 400;
-  font-style: normal;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  z-index: 1;
-  margin: 7px;
-  color: var(--xh-text-color-muted);
+.bp3-input-group {
+  svg:not(.bp3-icon) {
+    position: absolute;
+    top: 0;
+    line-height: 1;
+    font-size: var(--xh-font-size-large-px);
+    font-weight: 400;
+    font-style: normal;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    z-index: 1;
+    margin: 7px;
+    color: var(--xh-text-color-muted);
+  }
+
+  .bp3-button-group {
+    margin-right: 3px;
+
+    .bp3-button {
+      margin-right: 0;
+      margin-left: 0;
+    }
+
+    svg:not(.bp3-icon) {
+      margin-top: 4px;
+    }
+  }
 }
 
 // Avoid misaligned rightIcon within inputs.


### PR DESCRIPTION
Allows adding a clear button consistent with TextInput and Select, as well as allowing setting the `rightElement` if the app doesn't want any of the built-in buttons.

![image](https://user-images.githubusercontent.com/9619538/60213828-48485f00-9832-11e9-957e-609ccba58823.png)
