### PR TITLE
Move mobile app menu to right

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### ✨ Style
 
 * Panel splitter collapse button more visible in dark theme. CSS vars to customize further fixed.
+* The mobile app menu button has been moved to the right side of the top appBar, consistent with its
+  placement in desktop apps.
 
 ### 📚 Libraries
 

--- a/mobile/appcontainer/AppContainer.js
+++ b/mobile/appcontainer/AppContainer.js
@@ -123,7 +123,7 @@ export class AppContainer extends Component {
         return menu({
             model: model,
             width: 260,
-            align: 'left'
+            align: 'right'
         });
     }
 }

--- a/mobile/cmp/header/AppBar.js
+++ b/mobile/cmp/header/AppBar.js
@@ -10,7 +10,7 @@ import PT from 'prop-types';
 import {XH, HoistComponent, elemFactory} from '@xh/hoist/core';
 import {div} from '@xh/hoist/cmp/layout';
 import {toolbar} from '@xh/hoist/mobile/cmp/toolbar';
-import {navigatorBackButton, menuButton, refreshButton} from '@xh/hoist/mobile/cmp/button';
+import {button, navigatorBackButton, menuButton, refreshButton} from '@xh/hoist/mobile/cmp/button';
 
 import './AppBar.scss';
 
@@ -26,7 +26,7 @@ import './AppBar.scss';
 export class AppBar extends Component {
 
     static propTypes = {
-        /** Icon to display as the app menu icon, displayed to the left of the title. */
+        /** App icon to display to the left of the title. */
         icon: PT.element,
 
         /** Title to display to the center the AppBar. Defaults to XH.clientAppName. */
@@ -92,14 +92,17 @@ export class AppBar extends Component {
                             model: navigatorModel,
                             ...backButtonProps
                         }),
-                        menuButton({
-                            icon: icon,
-                            omit: hideAppMenuButton || !appMenuModel,
-                            model: appMenuModel,
-                            ...appMenuButtonProps
-                        }),
                         ...leftItems || []
                     ]
+                }),
+                button({
+                    icon: icon,
+                    omit: !icon,
+                    onClick: () => {
+                        if (XH.routerModel.hasRoute('default')) {
+                            XH.navigate('default');
+                        }
+                    }
                 }),
                 div({
                     className: 'xh-appbar-title',
@@ -113,6 +116,11 @@ export class AppBar extends Component {
                             omit: hideRefreshButton,
                             disabled: navigatorModel.disableAppRefreshButton,
                             ...refreshButtonProps
+                        }),
+                        menuButton({
+                            omit: hideAppMenuButton || !appMenuModel,
+                            model: appMenuModel,
+                            ...appMenuButtonProps
                         })
                     ]
                 })


### PR DESCRIPTION
+ Add app icon to left of title. Tapping it returns to home. See Toolbox PR: https://github.com/exhi/toolbox/pull/216
Fixes issue #1207