### PR TITLE
Percent formatter (and renderer) will multiply value by 100*,  Fixes: #1192

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### 🎁 Breaking Changes
 
 * Applications that have been using fmtPercent or fmtPercentRenderer methods should adjust to
-  their new behavior. Columns that were previously using `exportValue: v => v/100` as as workaround 
+  their new behavior. Columns that were previously using `exportValue: v => v/100` as a workaround 
   to the previous renderer behavior should remove this line of code.
 
 ## v24.1.1 - 2019-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## v25.0.0-SNAPSHOT - under development
 
-TBD
+### 🎁 New Features
+
+* The fmtPercent and fmtPercentRenderer methods will multiply provided value by 100. 
+  This is consistent with the behavior of Excel's percentage formatting.  
+
+### 🎁 Breaking Changes
+
+* Applications that have been using fmtPercent or fmtPercentRenderer methods should adjust to
+  their new behavior. Columns that were previously using `exportValue: v => v/100` as as workaround 
+  to the previous renderer behavior should remove this line of code.
 
 ## v24.1.1 - 2019-07-01
 

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -173,7 +173,7 @@ export function fmtPrice(v, opts = {}) {
 }
 
 /**
- * Render a number as a percent. Expects a value to be multiplied by 100 to calculated the percentage.
+ * Render a number as a percent. Value will be multiplied by 100 to calculated the percentage.
  * This behavior purposefully matches Microsoft Excel's percentage formatting.
  *
  * @param {number} v - value to format.

--- a/format/FormatNumber.js
+++ b/format/FormatNumber.js
@@ -173,7 +173,8 @@ export function fmtPrice(v, opts = {}) {
 }
 
 /**
- * Render a number as a percent
+ * Render a number as a percent. Expects a value to be multiplied by 100 to calculated the percentage.
+ * This behavior purposefully matches Microsoft Excel's percentage formatting.
  *
  * @param {number} v - value to format.
  * @param {Object} [opts] - @see {@link fmtNumber} method.
@@ -183,7 +184,7 @@ export function fmtPercent(v, opts = {}) {
     if (isInvalidInput(v)) return fmtNumber(v, opts);
 
     defaults(opts, {precision: 2, label: '%', labelCls: null});
-    return fmtNumber(v, opts);
+    return fmtNumber(v * 100, opts);
 }
 
 /**


### PR DESCRIPTION
Matches Excel behavior

+This will be a breaking change (and clean up to exportValue:  v => v/100 in appropriate cols) in client apps using it; should be added to changelog as such after merge

