### PR TITLE
Don't close DateInput popover when changing dates with time precision

### DIFF
--- a/desktop/cmp/input/DateInput.js
+++ b/desktop/cmp/input/DateInput.js
@@ -145,7 +145,7 @@ export class DateInput extends HoistInput {
                     minDate: this.minDate,
                     showActionsBar: props.showActionsBar,
                     dayPickerProps: assign({fixedWeeks: true}, props.dayPickerProps),
-                    timePickerProps: props.timePrecision ? props.timePickerProps : undefined,
+                    timePickerProps: props.timePrecision ? assign({selectAllOnFocus: true}, props.timePickerProps) : undefined,
                     timePrecision: props.timePrecision
                 }),
 
@@ -243,6 +243,9 @@ export class DateInput extends HoistInput {
     onDatePickerChange = (date, isUserChange) => {
         if (!isUserChange) return;
         this.onDateChange(date);
+        if (!this.props.timePrecision) {
+            this.setPopoverOpen(false);
+        }
     };
 
     onDateChange = (date) => {
@@ -252,9 +255,7 @@ export class DateInput extends HoistInput {
             if (maxDate && date > maxDate) date = maxDate;
             date = this.applyPrecision(date);
         }
-
         this.noteValueChange(date);
-        this.setPopoverOpen(false);
     };
 
     applyPrecision(date) {


### PR DESCRIPTION
Fixes Issue #1240

Hoist P/R Checklist
-------------------
* Up to date with develop branch?
	- [x] Yes
* Ready for review?
	- [x] Yes
	- [ ] No - WIP label applied to PR
* CHANGELOG entry?
	- [ ] Yes
	- [x] N/A - trivial or implementation changes only
* Breaking change?
	- [ ] Yes - breaking-change label applied to PR, noted in CHANGELOG
	- [x] No - no public APIs modified
* Docs updated?
	- [ ] Yes - doc comments and/or prop-types updated
	- [x] N/A - no related docs require changing
* Mobile support?
	- [ ] Yes - mobile-specific support or changes included
		- [ ] Tested on a real device
	- [x] No - mobile support not required or desired at this time
	- [ ] N/A - change not platform specific
* Toolbox branch / PR?
	- [ ] Yes - [provide branch or PR link]
	- [x] N/A - trivial change or nothing to update / demo in TBox
