### PR TITLE
Warn if param passed to loadAsync that does not appear to be a loadSpec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## v26.0.0-SNAPSHOT - under development
 
-* TBD
+### ⚙️ Technical
+
+* Classes decorated with `@LoadSupport` will now throw an exception out of their provided
+  `loadAsync()` method if called with a parameter that's not a plain object (i.e. param is clearly
+  not a `LoadSpec`). Note this might be a breaking change, in so far as it introduces additional
+  validation around this pre-existing API requirement.
 
 ## v25.0.0 - 2019-07-16
 

--- a/core/mixins/LoadSupport.js
+++ b/core/mixins/LoadSupport.js
@@ -52,7 +52,7 @@ export function LoadSupport(C) {
              */
             async loadAsync(loadSpec = {}) {
                 throwIf(
-                    (!isPlainObject(loadSpec)),
+                    !isPlainObject(loadSpec),
                     'Unexpected param passed to loadAsync() - accepts loadSpec object only. If triggered via a reaction, ensure call is wrapped in a closure.'
                 );
 

--- a/core/mixins/LoadSupport.js
+++ b/core/mixins/LoadSupport.js
@@ -5,10 +5,10 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {XH} from '@xh/hoist/core';
-import {applyMixin, warnIf} from '@xh/hoist/utils/js';
+import {applyMixin, throwIf} from '@xh/hoist/utils/js';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {allSettled} from '@xh/hoist/promise';
-import {isPlainObject, isNil} from 'lodash';
+import {isPlainObject} from 'lodash';
 
 /**
  * Mixin to indicate that an object has a load and refresh lifecycle for loading data from backend
@@ -51,8 +51,8 @@ export function LoadSupport(C) {
              * @param {LoadSpec} [loadSpec] - Metadata about the underlying request
              */
             async loadAsync(loadSpec = {}) {
-                warnIf(
-                    (!isNil(loadSpec) && !isPlainObject(loadSpec)),
+                throwIf(
+                    (!isPlainObject(loadSpec)),
                     'Unexpected param passed to loadAsync() - accepts loadSpec object only. If triggered via a reaction, ensure call is wrapped in a closure.'
                 );
 

--- a/core/mixins/LoadSupport.js
+++ b/core/mixins/LoadSupport.js
@@ -5,9 +5,10 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {XH} from '@xh/hoist/core';
-import {applyMixin} from '@xh/hoist/utils/js';
+import {applyMixin, warnIf} from '@xh/hoist/utils/js';
 import {PendingTaskModel} from '@xh/hoist/utils/async';
 import {allSettled} from '@xh/hoist/promise';
+import {isPlainObject, isNil} from 'lodash';
 
 /**
  * Mixin to indicate that an object has a load and refresh lifecycle for loading data from backend
@@ -50,6 +51,10 @@ export function LoadSupport(C) {
              * @param {LoadSpec} [loadSpec] - Metadata about the underlying request
              */
             async loadAsync(loadSpec = {}) {
+                warnIf(
+                    (!isNil(loadSpec) && !isPlainObject(loadSpec)),
+                    'Unexpected param passed to loadAsync() - accepts loadSpec object only. If triggered via a reaction, ensure call is wrapped in a closure.'
+                );
 
                 this.lastLoadRequested = new Date();
                 const loadModel = !loadSpec.isAutoRefresh ? this.loadModel : null;


### PR DESCRIPTION
+ This appears to be a common mistake, typically made by binding loadAsync directly to a reaction - it's then passed whatever is being tracked.
+ Won't catch cases where tracked observable is a plain object and is unintentionally passed in, but this seemed better than nothing.

Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [x] Reviewed and tested on Mobile (or N/A)
- [x] Created Toolbox branch / PR (N/A)
