### PR TITLE
Support secondaryText prop on RecordAction (Fixes #1276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## v26.0.0-SNAPSHOT - under development
 
-TBD
+### 🎁 New Features
+
+* `RecordAction` supports a new `secondaryText` property. When used for a Grid context menu item,
+  this text appears on the right side of the menu item, usually used for displaying the shortcut
+  key associated with an action. 
 
 [Commit Log](https://github.com/exhi/hoist-react/compare/v25.1.0...develop)
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -319,6 +319,7 @@ export class Grid extends Component {
 
             items.push({
                 name: displaySpec.text,
+                shortcut: displaySpec.secondaryText,
                 icon,
                 subMenu: childItems,
                 tooltip: displaySpec.tooltip,

--- a/data/RecordAction.js
+++ b/data/RecordAction.js
@@ -24,6 +24,7 @@ import {isBoolean, isNumber, isNil, isEmpty} from 'lodash';
 export class RecordAction {
 
     text;
+    secondaryText;
     icon;
     intent;
     tooltip;
@@ -37,6 +38,7 @@ export class RecordAction {
     /**
      * @param {Object} c - RecordAction configuration.
      * @param {string} [c.text] - label to be displayed.
+     * @param {string} [c.secondaryText] - additional label to be displayed, usually in a minimal fashion.
      * @param {Object} [c.icon] - icon to be displayed.
      * @param {string} [c.intent] - intent to be used for rendering the action.
      * @param {string} [c.tooltip] - tooltip to display when hovering over the action.
@@ -54,6 +56,7 @@ export class RecordAction {
      */
     constructor({
         text,
+        secondaryText,
         icon = null,
         intent,
         tooltip,
@@ -65,6 +68,7 @@ export class RecordAction {
         recordsRequired = false
     }) {
         this.text = text;
+        this.secondaryText = secondaryText;
         this.icon = icon;
         this.intent = intent;
         this.tooltip = tooltip;
@@ -95,6 +99,7 @@ export class RecordAction {
         const defaultDisplay = {
             icon: this.icon,
             text: this.text,
+            secondaryText: this.secondaryText,
             intent: this.intent,
             tooltip: this.tooltip,
             items: this.items,


### PR DESCRIPTION
New prop in RecordAction for secondary text/label. 

The only usage of RecordAction where it makes sense to use this is in the grid context menu, where it is mapped to the `shortcut` prop in the ag-Grid menu item. Other usages of RecordActions are in buttons where an additional label doesn't really make sense (we already have tooltip support via RecordAction).

Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [x] Reviewed and tested on Mobile (or N/A)
- [x] Created Toolbox branch / PR (link provided here, or N/A)
