### PR TITLE
add logic to find inputRef when Select has enableCreate  = true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   independent. Specify a single `getCopyText` function rather than the `clipboardSpec`.
   (`clipboardSpec` is an artifact from the removed `clipboard` library).
 
+### 🐞 Bug Fixes
+
+* The `Select.selectOnFocus` prop is now respected when used in tandem with `enableCreate` and/or
+  `queryFn` props.
+
 ### ⚙️ Technical
 
 * `AgGridModel` will now throw an exception if any of its methods which depend on ag-Grid state are

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -282,8 +282,12 @@ export class Select extends HoistInput {
         if (this.props.selectOnFocus) {
             wait(1).then(() => {
                 // Delay to allow re-render. For safety, only select if still focused!
-                const rsRef = this.reactSelectRef.current,
-                    inputElem = rsRef ? rsRef.select.inputRef : null;
+                const rsRef = this.reactSelectRef.current;
+                if (!rsRef) return;
+
+                const selectCls = rsRef.select.constructor.name == 'Creatable' ? rsRef.select.select : rsRef.select,
+                    inputElem = selectCls.inputRef;
+                    
                 if (this.hasFocus && inputElem && document.activeElement == inputElem) {
                     inputElem.select();
                 }

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -285,8 +285,11 @@ export class Select extends HoistInput {
                 const rsRef = this.reactSelectRef.current;
                 if (!rsRef) return;
 
-                const selectCls = rsRef.select.constructor.name == 'Select' ? rsRef.select : rsRef.select.select,
-                    inputElem = selectCls.inputRef;
+                // Use of creatable and async variants will create another level of nesting we must
+                // traverse to get to the underlying Select comp and its inputRef.
+                const refComp = rsRef.select,
+                    selectComp = refComp.constructor.name == 'Select' ? refComp : refComp.select,
+                    inputElem = selectComp.inputRef;
 
                 if (this.hasFocus && inputElem && document.activeElement == inputElem) {
                     inputElem.select();
@@ -295,7 +298,6 @@ export class Select extends HoistInput {
         }
         super.noteFocused();
     }
-
 
     //-------------------------
     // Options / value handling
@@ -377,14 +379,14 @@ export class Select extends HoistInput {
                 // But only return the matching options back to the combo.
                 return matchOpts;
             });
-    }
+    };
 
     loadingMessageFn = (params) => {
         const {loadingMessageFn} = this.props,
             q = params.inputValue;
 
         return loadingMessageFn ? loadingMessageFn(q) : 'Loading...';
-    }
+    };
 
 
     //----------------------
@@ -401,7 +403,7 @@ export class Select extends HoistInput {
         // implementation here to render a checkmark next to the active selection.
         const optionRenderer = this.props.optionRenderer || this.optionRenderer;
         return optionRenderer(opt);
-    }
+    };
 
     optionRenderer = (opt) => {
         if (this.suppressCheck) {
@@ -417,7 +419,7 @@ export class Select extends HoistInput {
                 span(opt.label)
             ) :
             div({item: opt.label, style: {paddingLeft: 25}});
-    }
+    };
 
     get suppressCheck() {
         const {props} = this;
@@ -444,12 +446,12 @@ export class Select extends HoistInput {
         if (noOptionsMessageFn) return noOptionsMessageFn(q);
         if (q) return 'No matches found.';
         return this.asyncMode ? 'Type to search...' : '';
-    }
+    };
 
     createMessageFn = (q) => {
         const {createMessageFn} = this.props;
         return createMessageFn ? createMessageFn(q) : `Create "${q}"`;
-    }
+    };
 
     getOrCreatePortalDiv() {
         let portal = document.getElementById('xh-select-input-portal');

--- a/desktop/cmp/input/Select.js
+++ b/desktop/cmp/input/Select.js
@@ -285,9 +285,9 @@ export class Select extends HoistInput {
                 const rsRef = this.reactSelectRef.current;
                 if (!rsRef) return;
 
-                const selectCls = rsRef.select.constructor.name == 'Creatable' ? rsRef.select.select : rsRef.select,
+                const selectCls = rsRef.select.constructor.name == 'Select' ? rsRef.select : rsRef.select.select,
                     inputElem = selectCls.inputRef;
-                    
+
                 if (this.hasFocus && inputElem && document.activeElement == inputElem) {
                     inputElem.select();
                 }


### PR DESCRIPTION
Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [N/A] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [x] Created Toolbox branch / PR [ToolBox PR](https://github.com/exhi/toolbox/pull/236)


This fixes an issue I found in the Select component on desktop:  When a Select component has enableCreate = true, the selectOnFocus logic was not finding the correct class from which to get the inputRef.   With this fix, the inputRef is found whether or not enableCreate = true.

I'll add a change log entry once we decide whether to put this in release 26 or in release 25.2.1

-Colin