### PR TITLE
Allow autoFocus of button, and of input, cancel, or primary button in messages and prompts. (#1284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,35 +15,38 @@
   * The service will monitor the socket connection with a regular heartbeat and attempt to
     re-establish if dropped.
   * A new admin console snap-in provides an overview of connected websocket clients.
-
 * New `GridCountLabel` component provides an alternative to existing `StoreCountLabel`, outputting
   both overall record count and current selection count in a configurable way.
-
-* `GridModel` now supports a `copyCell` context menu action. See `StoreContextMenu` for more details.
-
+* `GridModel` now supports a `copyCell` context menu action. See `StoreContextMenu` for more
+  details.
+* `Button` component accepts an `autoFocus` prop to attempt to focus on render.
+* The `XH.message()` and related methods such as `XH.alert()` now support more flexible
+  `confirmProps` and `cancelProps` configs, each of which will be passed to their respective button
+  and merged with suitable defaults. Allows use of the new `autoFocus` prop with these preconfigured
+  dialogs.
+  * The previous text/intent configs have been deprecated and the message methods will log a console
+    warning if they are used (although it will continue to respect them to aid transitioning to the
+    new configs).
 
 ### 💥 Breaking Changes
 
 * `StoreCountLabel` has been moved from `/desktop/cmp/store` to the cross-platform package
   `/cmp/store`. Its `gridModel` prop has also been removed - usages with grids should likely switch
   to the new `GridCountLabel` component, noted above and imported from `/cmp/grid`.
-
 * The API for `ClipboardButton` and `ClipboardMenuItem` has been simplified, and made implementation
-independent.  Specify a single `getCopyText` function rather than the `clipboardSpec`.  (`clipboardSpec`
-is an artifact from the removed `clipboard` library).
-
+  independent. Specify a single `getCopyText` function rather than the `clipboardSpec`.
+  (`clipboardSpec` is an artifact from the removed `clipboard` library).
 
 ### ⚙️ Technical
 
-* `AgGridModel` will now throw an exception if any of its methods which depend on ag-Grid state
-  are called before the grid has been fully initialized (ag-Grid onGridReady event has fired).
-  Applications can check the new `isReady` property on `AgGridModel` before calling such methods
-  to verify the grid is fully initialized.
-  
+* `AgGridModel` will now throw an exception if any of its methods which depend on ag-Grid state are
+  called before the grid has been fully initialized (ag-Grid onGridReady event has fired).
+  Applications can check the new `isReady` property on `AgGridModel` before calling such methods to
+  verify the grid is fully initialized.
+
 ### 📚 Libraries
 
 * ag-Grid `21.0.1 -> 21.1.0`
-
 * The `clipboard` library has been replaced with the simpler `clipboard-copy` library.
 
 ## v25.2.0 - 2019-07-25

--- a/admin/tabs/general/websocket/WebSocketModel.js
+++ b/admin/tabs/general/websocket/WebSocketModel.js
@@ -95,10 +95,10 @@ export class WebSocketModel {
         const message = await XH.prompt({
             title: 'Send test alert',
             icon: Icon.bullhorn(),
-            confirmText: 'Send',
+            confirmProps: {text: 'Send'},
             message: `Send an in-app alert to ${selectedRecord.authUser} with the text below.`,
             input: {
-                item: textInput(),
+                item: textInput({autoFocus: true, selectOnFocus: true}),
                 value: 'This is a test alert',
                 rules: [required]
             }

--- a/core/XH.js
+++ b/core/XH.js
@@ -308,15 +308,17 @@ class XHClass {
      * @param {string} config.message - message text to be displayed.
      * @param {string} [config.title] - title of message box.
      * @param {Element} [config.icon] - icon to be displayed.
-     * @param {MessageInput} [config.input] - config for input to be displayed.
-     * @param {string} [config.confirmText] - Text for confirm button. If null, no button will be shown.
-     * @param {string} [config.cancelText] - Text for cancel button. If null, no button will be shown.
-     * @param {string} [config.confirmIntent] - Blueprint Intent for confirm button (desktop only).
-     * @param {string} [config.cancelIntent] - Blueprint Intent for cancel button (desktop only).
+     * @param {MessageInput} [config.input] - config for input to be displayed (as a prompt).
+     * @param {string} [config.confirmProps] - props for primary confirm button.
+     *      Must provide either text or icon for button to be displayed, or use a preconfigured
+     *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
+     * @param {string} [config.cancelProps] - props for secondary cancel button.
+     *      Must provide either text or icon for button to be displayed, or use a preconfigured
+     *      helper such as `XH.alert()` or `XH.confirm()` for default buttons.
      * @param {function} [config.onConfirm] - Callback to execute when confirm is clicked.
      * @param {function} [config.onCancel] - Callback to execute when cancel is clicked.
      *
-     * @returns {Promise} - A Promise that will resolve to true if user confirms, and false if user cancels.
+     * @returns {Promise} - Promise resolving to true if user confirms, false if user cancels.
      *      If an input is provided, the Promise will resolve to the input value if user confirms.
      */
     message(config) {

--- a/core/appcontainer/MessageModel.js
+++ b/core/appcontainer/MessageModel.js
@@ -11,64 +11,56 @@ import {warnIf} from '@xh/hoist/utils/js';
 
 /**
  * Model for a single instance of a modal dialog.
- *
+ * Not intended for direct application use. {@see XHClass#message()} and related for the public API.
  * @private
  */
 @HoistModel
 export class MessageModel {
 
     // Immutable properties
-    title = null;
-    icon = null;
-    message = null;
-    input = null;
-    confirmProps = {};
-    cancelProps = {};
-    confirmText = null;
-    cancelText = null;
-    confirmIntent = null;
-    cancelIntent = null;
-    onConfirm = null;
-    onCancel = null;
+    title;
+    icon;
+    message;
+    input;
+    confirmProps;
+    cancelProps;
+    onConfirm;
+    onCancel;
 
     // Promise to be resolved when user has clicked on choice and its internal resolver
-    result = null;
-    _resolver = null;
+    result;
+    _resolver;
 
     @observable isOpen = true;
 
-    constructor(config) {
+    constructor({
+        title,
+        icon,
+        message,
+        input,
+        confirmProps = {},
+        cancelProps = {},
+        onConfirm,
+        onCancel,
+
+        // Deprecated
+        confirmText,
+        confirmIntent,
+        cancelText,
+        cancelIntent
+    }) {
         warnIf(
-            (
-                config.confirmText || 
-            config.confirmIntent ||
-            config.cancelText ||
-            config.cancelIntent
-            )
-            , 
-            `Message config properties "confirmText", "confirmIntent", "cancelText", and "cancelIntent" are scheduled for deprecation in release 27.
-              Please pass in button configs using "confirmProps" and "cancelProps" instead.`
+            (confirmText || confirmIntent || cancelText || cancelIntent),
+            'Message "confirmText", "confirmIntent", "cancelText", and "cancelIntent" configs have been deprecated - use "confirmProps" and "cancelProps" instead.'
         );
 
+        this.title = title;
+        this.icon = icon;
+        this.message = message;
 
-        this.title = config.title;
-        this.icon = config.icon;
-        this.message = config.message;
-        this.input = config.input;
-        this.confirmProps = config.confirmProps || {};
-        this.cancelProps = config.cancelProps || {};
-        this.confirmText = config.confirmText;
-        this.cancelText = config.cancelText;
-        this.confirmIntent = config.confirmIntent;
-        this.cancelIntent = config.cancelIntent;
-        this.onConfirm = config.onConfirm;
-        this.onCancel = config.onCancel;
-        this.result = new Promise(resolve => this._resolver = resolve);
-
-        // Extract properties from input
-        if (this.input) {
-            const {value, rules} = this.input;
-
+        if (input) {
+            this.input = input;
+            const {value, rules} = input;
             this.formModel = this.markManaged(new FormModel({
                 fields: [{
                     name: 'value',
@@ -77,6 +69,13 @@ export class MessageModel {
                 }]
             }));
         }
+
+        this.confirmProps = this.parseButtonProps(confirmProps, () => this.doConfirmAsync(), confirmText, confirmIntent);
+        this.cancelProps = this.parseButtonProps(cancelProps, () => this.doCancel(), cancelText, cancelIntent);
+
+        this.onConfirm = onConfirm;
+        this.onCancel = onCancel;
+        this.result = new Promise(resolve => this._resolver = resolve);
 
         // Message modals are automatically dismissed on app route changes to avoid navigating the
         // app underneath the dialog in an unsettling way.
@@ -118,6 +117,15 @@ export class MessageModel {
 
     destroy() {
         this.close();
+    }
+
+    // Merge handler and deprecated props into consolidated object.
+    // Return null if neither text nor icon provided - button should not be displayed.
+    parseButtonProps(props, handler, deprText, deprIntent) {
+        const ret = {...props, onClick: handler};
+        if (deprText) ret.text = deprText;
+        if (deprIntent) ret.intent = deprIntent;
+        return (ret.text || ret.icon) ? ret : null;
     }
 }
 

--- a/core/appcontainer/MessageModel.js
+++ b/core/appcontainer/MessageModel.js
@@ -24,10 +24,10 @@ export class MessageModel {
     confirmText = null;
     cancelText = null;
     confirmIntent = null;
-    confirmAutoFocus = null;
     cancelIntent = null;
     onConfirm = null;
     onCancel = null;
+    autoFocus = 'input';  // allowed values: 'input', 'cancel', 'confirm'
 
     // Promise to be resolved when user has clicked on choice and its internal resolver
     result = null;
@@ -43,10 +43,10 @@ export class MessageModel {
         this.confirmText = config.confirmText;
         this.cancelText = config.cancelText;
         this.confirmIntent = config.confirmIntent;
-        this.confirmAutoFocus = config.confirmAutoFocus;
         this.cancelIntent = config.cancelIntent;
         this.onConfirm = config.onConfirm;
         this.onCancel = config.onCancel;
+        this.autoFocus = config.autoFocus ? config.autoFocus : this.autoFocus;
         this.result = new Promise(resolve => this._resolver = resolve);
 
         // Extract properties from input

--- a/core/appcontainer/MessageModel.js
+++ b/core/appcontainer/MessageModel.js
@@ -7,6 +7,7 @@
 import {HoistModel, XH} from '@xh/hoist/core';
 import {observable, action} from '@xh/hoist/mobx';
 import {FormModel} from '@xh/hoist/cmp/form';
+import {warnIf} from '@xh/hoist/utils/js';
 
 /**
  * Model for a single instance of a modal dialog.
@@ -21,13 +22,14 @@ export class MessageModel {
     icon = null;
     message = null;
     input = null;
+    confirmProps = {};
+    cancelProps = {};
     confirmText = null;
     cancelText = null;
     confirmIntent = null;
     cancelIntent = null;
     onConfirm = null;
     onCancel = null;
-    autoFocus = 'input';  // allowed values: 'input', 'cancel', 'confirm'
 
     // Promise to be resolved when user has clicked on choice and its internal resolver
     result = null;
@@ -36,17 +38,31 @@ export class MessageModel {
     @observable isOpen = true;
 
     constructor(config) {
+        warnIf(
+            (
+                config.confirmText || 
+            config.confirmIntent ||
+            config.cancelText ||
+            config.cancelIntent
+            )
+            , 
+            `Message config properties "confirmText", "confirmIntent", "cancelText", and "cancelIntent" are scheduled for deprecation in release 27.
+              Please pass in button configs using "confirmProps" and "cancelProps" instead.`
+        );
+
+
         this.title = config.title;
         this.icon = config.icon;
         this.message = config.message;
         this.input = config.input;
+        this.confirmProps = config.confirmProps || {};
+        this.cancelProps = config.cancelProps || {};
         this.confirmText = config.confirmText;
         this.cancelText = config.cancelText;
         this.confirmIntent = config.confirmIntent;
         this.cancelIntent = config.cancelIntent;
         this.onConfirm = config.onConfirm;
         this.onCancel = config.onCancel;
-        this.autoFocus = config.autoFocus ? config.autoFocus : this.autoFocus;
         this.result = new Promise(resolve => this._resolver = resolve);
 
         // Extract properties from input

--- a/core/appcontainer/MessageModel.js
+++ b/core/appcontainer/MessageModel.js
@@ -24,6 +24,7 @@ export class MessageModel {
     confirmText = null;
     cancelText = null;
     confirmIntent = null;
+    confirmAutoFocus = null;
     cancelIntent = null;
     onConfirm = null;
     onCancel = null;
@@ -42,6 +43,7 @@ export class MessageModel {
         this.confirmText = config.confirmText;
         this.cancelText = config.cancelText;
         this.confirmIntent = config.confirmIntent;
+        this.confirmAutoFocus = config.confirmAutoFocus;
         this.cancelIntent = config.cancelIntent;
         this.onConfirm = config.onConfirm;
         this.onCancel = config.onCancel;

--- a/core/appcontainer/MessageSourceModel.js
+++ b/core/appcontainer/MessageSourceModel.js
@@ -5,7 +5,7 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 
-import {defaults} from 'lodash';
+import {defaultsDeep} from 'lodash';
 import {observable, action} from '@xh/hoist/mobx';
 import {HoistModel, managed} from '@xh/hoist/core';
 
@@ -30,17 +30,17 @@ export class MessageSourceModel {
     }
 
     alert(config) {
-        config = defaults({}, config, {confirmText: 'OK'});
+        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}});
         return this.message(config);
     }
 
     confirm(config) {
-        config = defaults({}, config, {confirmText: 'OK', cancelText: 'Cancel'});
+        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}, cancelProps: {text: 'Cancel'}});
         return this.message(config);
     }
 
     prompt(config) {
-        config = defaults({}, config, {confirmText: 'OK', cancelText: 'Cancel', input: {}});
+        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}, cancelProps: {text: 'Cancel'}, input: {}});
         return this.message(config);
     }
 

--- a/core/appcontainer/MessageSourceModel.js
+++ b/core/appcontainer/MessageSourceModel.js
@@ -5,16 +5,15 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 
-import {defaultsDeep} from 'lodash';
-import {observable, action} from '@xh/hoist/mobx';
 import {HoistModel, managed} from '@xh/hoist/core';
+import {action, observable} from '@xh/hoist/mobx';
 
 import {MessageModel} from './MessageModel';
 
 /**
- *  Supports displaying Modal Dialogs.
- *
- *  @private
+ * Supports managed display of modal message dialogs via `XH.message()` and friends.
+ * Not intended for direct application use. {@see XHClass#message()} and related for the public API.
+ * @private
  */
 @HoistModel
 export class MessageSourceModel {
@@ -30,18 +29,27 @@ export class MessageSourceModel {
     }
 
     alert(config) {
-        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}});
-        return this.message(config);
+        return this.message({
+            ...config,
+            confirmProps: {text: 'OK', autoFocus: true, ...config.confirmProps}
+        });
     }
 
     confirm(config) {
-        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}, cancelProps: {text: 'Cancel'}});
-        return this.message(config);
+        return this.message({
+            ...config,
+            confirmProps: {text: 'OK', ...config.confirmProps},
+            cancelProps: {text: 'Cancel', ...config.cancelProps}
+        });
     }
 
     prompt(config) {
-        config = defaultsDeep({}, config, {confirmProps: {text: 'OK'}, cancelProps: {text: 'Cancel'}, input: {}});
-        return this.message(config);
+        return this.message({
+            ...config,
+            confirmProps: {text: 'OK', ...config.confirmProps},
+            cancelProps: {text: 'Cancel', ...config.cancelProps},
+            input: config.input || {}
+        });
     }
 
     //-----------------------------------
@@ -62,4 +70,5 @@ export class MessageSourceModel {
         this.msgModels = keepModels;
         cullModels.forEach(it => it.destroy());
     }
+
 }

--- a/desktop/appcontainer/ExceptionDialog.js
+++ b/desktop/appcontainer/ExceptionDialog.js
@@ -91,10 +91,12 @@ class DismissButton extends Component {
             button({
                 icon: Icon.refresh(),
                 text: this.sessionExpired() ? 'Login' : 'Reload App',
+                autoFocus: true,
                 onClick: this.onReloadClick
             }) :
             button({
                 text: 'Close',
+                autoFocus: true,
                 onClick: this.onCloseClick
             });
     }

--- a/desktop/appcontainer/IdleDialog.js
+++ b/desktop/appcontainer/IdleDialog.js
@@ -15,10 +15,7 @@ import {message} from './Message';
 
 /**
  * Default dialog to display when the app has suspended itself due to inactivity.
- *
- * This display can be overridden by applications.
- * @see AppSpec.idleDialogClass
- *
+ * This display can be overridden by applications - {@see AppSpec.idleDialogClass}.
  * @private
  */
 @HoistComponent
@@ -40,8 +37,12 @@ export class IdleDialog extends Component {
                         p('Please click below to reload it.')
                     ]
                 }),
-                confirmIntent: 'primary',
-                confirmText: 'I\'m back',
+                confirmProps: {
+                    text: "I'm back!",
+                    intent: 'primary',
+                    minimal: false,
+                    autoFocus: true
+                },
                 onConfirm: this.props.onReactivate
             },
             className: 'xh-idle-dialog'

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -5,6 +5,7 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {Component} from 'react';
+import {defaults} from 'lodash';
 
 import {dialog, dialogBody} from '@xh/hoist/kit/blueprint';
 import {HoistComponent, elemFactory} from '@xh/hoist/core';
@@ -55,39 +56,44 @@ export class Message extends Component {
     }
 
     renderInput() {
-        const {formModel, input, autoFocus} = this.model;
+        const {formModel, input} = this.model;
         if (!formModel) return null;
         return form({
             model: formModel,
             fieldDefaults: {commitOnChange: true, minimal: true, label: null},
             item: formField({
                 field: 'value',
-                item: withDefault(input.item, textInput({
-                    autoFocus:  autoFocus == 'input'
-                }))
+                item: withDefault(input.item, textInput({autoFocus: true}))
             })
         });
     }
 
     renderButtons() {
-        const {formModel, confirmText, cancelText, confirmIntent, cancelIntent, autoFocus} = this.model;
+        const {formModel, confirmProps, cancelProps, confirmText, cancelText, confirmIntent, cancelIntent} = this.model;
         return [
             filler(),
-            button({
-                text: cancelText,
-                omit: !cancelText,
-                intent: cancelIntent,
-                autoFocus:  autoFocus == 'cancel',
-                onClick: () => this.model.doCancel()
-            }),
-            button({
-                text: confirmText,
-                intent: confirmIntent,
-                disabled: formModel ? !formModel.isValid : false,
-                autoFocus:  autoFocus == 'confirm',
-                minimal: false,
-                onClick: () => this.model.doConfirmAsync()
-            })
+            button(
+                defaults(
+                    cancelProps, 
+                    {
+                        text: cancelText,
+                        omit: !cancelProps.text,
+                        intent: cancelIntent,
+                        onClick: () => this.model.doCancel()
+                    }
+                )
+            ),
+            button(
+                defaults(
+                    confirmProps, 
+                    {
+                        text: confirmText,
+                        intent: confirmIntent,
+                        disabled: formModel ? !formModel.isValid : false,
+                        onClick: () => this.model.doConfirmAsync()
+                    }
+                )
+            )
         ];
     }
 

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -5,7 +5,6 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {Component} from 'react';
-import {FocusStyleManager} from '@blueprintjs/core';
 
 import {dialog, dialogBody} from '@xh/hoist/kit/blueprint';
 import {HoistComponent, elemFactory} from '@xh/hoist/core';
@@ -32,7 +31,6 @@ export class Message extends Component {
     baseClassName = 'xh-message';
 
     render() {
-        FocusStyleManager.alwaysShowFocus();
 
         const model = this.model,
             isOpen = model && model.isOpen;
@@ -57,7 +55,7 @@ export class Message extends Component {
     }
 
     renderInput() {
-        const {formModel, input, confirmAutoFocus} = this.model;
+        const {formModel, input, autoFocus} = this.model;
         if (!formModel) return null;
         return form({
             model: formModel,
@@ -65,34 +63,33 @@ export class Message extends Component {
             item: formField({
                 field: 'value',
                 item: withDefault(input.item, textInput({
-                    autoFocus: confirmAutoFocus ? false : true
+                    autoFocus:  autoFocus == 'input' ? true : false
                 }))
             })
         });
     }
 
     renderButtons() {
-        const {formModel, confirmText, cancelText, confirmIntent, cancelIntent, confirmAutoFocus} = this.model;
+        const {formModel, confirmText, cancelText, confirmIntent, cancelIntent, autoFocus} = this.model;
         return [
             filler(),
             button({
                 text: cancelText,
                 omit: !cancelText,
                 intent: cancelIntent,
+                autoFocus:  autoFocus == 'cancel' ? true : false,
                 onClick: () => this.model.doCancel()
             }),
             button({
                 text: confirmText,
                 intent: confirmIntent,
                 disabled: formModel ? !formModel.isValid : false,
-                autoFocus: confirmAutoFocus,
+                autoFocus:  autoFocus == 'confirm' ? true : false,
+                // minimal: false,
                 onClick: () => this.model.doConfirmAsync()
             })
         ];
     }
 
-    destroy() {
-        FocusStyleManager.onlyShowFocusOnTabs();
-    }
 }
 export const message = elemFactory(Message);

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -5,6 +5,8 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {Component} from 'react';
+import {FocusStyleManager} from '@blueprintjs/core';
+
 import {dialog, dialogBody} from '@xh/hoist/kit/blueprint';
 import {HoistComponent, elemFactory} from '@xh/hoist/core';
 import {filler} from '@xh/hoist/cmp/layout';
@@ -30,6 +32,8 @@ export class Message extends Component {
     baseClassName = 'xh-message';
 
     render() {
+        FocusStyleManager.alwaysShowFocus();
+
         const model = this.model,
             isOpen = model && model.isOpen;
 
@@ -53,20 +57,22 @@ export class Message extends Component {
     }
 
     renderInput() {
-        const {formModel, input} = this.model;
+        const {formModel, input, confirmAutoFocus} = this.model;
         if (!formModel) return null;
         return form({
             model: formModel,
             fieldDefaults: {commitOnChange: true, minimal: true, label: null},
             item: formField({
                 field: 'value',
-                item: withDefault(input.item, textInput({autoFocus: true}))
+                item: withDefault(input.item, textInput({
+                    autoFocus: confirmAutoFocus ? false : true
+                }))
             })
         });
     }
 
     renderButtons() {
-        const {formModel, confirmText, cancelText, confirmIntent, cancelIntent} = this.model;
+        const {formModel, confirmText, cancelText, confirmIntent, cancelIntent, confirmAutoFocus} = this.model;
         return [
             filler(),
             button({
@@ -79,10 +85,14 @@ export class Message extends Component {
                 text: confirmText,
                 intent: confirmIntent,
                 disabled: formModel ? !formModel.isValid : false,
+                autoFocus: confirmAutoFocus,
                 onClick: () => this.model.doConfirmAsync()
             })
         ];
     }
 
+    destroy() {
+        FocusStyleManager.onlyShowFocusOnTabs();
+    }
 }
 export const message = elemFactory(Message);

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -63,7 +63,7 @@ export class Message extends Component {
             item: formField({
                 field: 'value',
                 item: withDefault(input.item, textInput({
-                    autoFocus:  autoFocus == 'input' ? true : false
+                    autoFocus:  autoFocus == 'input'
                 }))
             })
         });
@@ -77,15 +77,15 @@ export class Message extends Component {
                 text: cancelText,
                 omit: !cancelText,
                 intent: cancelIntent,
-                autoFocus:  autoFocus == 'cancel' ? true : false,
+                autoFocus:  autoFocus == 'cancel',
                 onClick: () => this.model.doCancel()
             }),
             button({
                 text: confirmText,
                 intent: confirmIntent,
                 disabled: formModel ? !formModel.isValid : false,
-                autoFocus:  autoFocus == 'confirm' ? true : false,
-                // minimal: false,
+                autoFocus:  autoFocus == 'confirm',
+                minimal: false,
                 onClick: () => this.model.doConfirmAsync()
             })
         ];

--- a/desktop/appcontainer/Message.js
+++ b/desktop/appcontainer/Message.js
@@ -4,25 +4,23 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {Component} from 'react';
-import {defaults} from 'lodash';
-
-import {dialog, dialogBody} from '@xh/hoist/kit/blueprint';
-import {HoistComponent, elemFactory} from '@xh/hoist/core';
-import {filler} from '@xh/hoist/cmp/layout';
 import {form} from '@xh/hoist/cmp/form';
+import {filler} from '@xh/hoist/cmp/layout';
+import {elemFactory, HoistComponent} from '@xh/hoist/core';
+import {MessageModel} from '@xh/hoist/core/appcontainer/MessageModel';
+import {button} from '@xh/hoist/desktop/cmp/button';
 import {formField} from '@xh/hoist/desktop/cmp/form';
 import {textInput} from '@xh/hoist/desktop/cmp/input';
 import {toolbar} from '@xh/hoist/desktop/cmp/toolbar';
-import {button} from '@xh/hoist/desktop/cmp/button';
+import {dialog, dialogBody} from '@xh/hoist/kit/blueprint';
 import {withDefault} from '@xh/hoist/utils/js';
+import {Component} from 'react';
 
 import './Message.scss';
-import {MessageModel} from '@xh/hoist/core/appcontainer/MessageModel';
 
 /**
- * A modal dialog that supports imperative alert/confirm.
- *
+ * A preconfigured dialog component used to render modal messages.
+ * Not intended for direct application use. {@see XHClass#message()} and related for the public API.
  * @private
  */
 @HoistComponent
@@ -32,7 +30,6 @@ export class Message extends Component {
     baseClassName = 'xh-message';
 
     render() {
-
         const model = this.model,
             isOpen = model && model.isOpen;
 
@@ -69,32 +66,22 @@ export class Message extends Component {
     }
 
     renderButtons() {
-        const {formModel, confirmProps, cancelProps, confirmText, cancelText, confirmIntent, cancelIntent} = this.model;
-        return [
-            filler(),
-            button(
-                defaults(
-                    cancelProps, 
-                    {
-                        text: cancelText,
-                        omit: !cancelProps.text,
-                        intent: cancelIntent,
-                        onClick: () => this.model.doCancel()
-                    }
-                )
-            ),
-            button(
-                defaults(
-                    confirmProps, 
-                    {
-                        text: confirmText,
-                        intent: confirmIntent,
-                        disabled: formModel ? !formModel.isValid : false,
-                        onClick: () => this.model.doConfirmAsync()
-                    }
-                )
-            )
-        ];
+        const {confirmProps, cancelProps, formModel} = this.model,
+            ret = [filler()];
+
+        if (cancelProps) {
+            ret.push(button(cancelProps));
+        }
+
+        if (confirmProps) {
+            // Merge in formModel.isValid here in render stage to get reactivity.
+            ret.push(formModel ?
+                button({...confirmProps, disabled: !formModel.isValid}) :
+                button(confirmProps)
+            );
+        }
+
+        return ret;
     }
 
 }

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -24,13 +24,26 @@ import './Button.scss';
 export class Button extends Component {
 
     static propTypes = {
+        /** True to attempt to auto-focus this button on render. */
+        autoFocus: PT.bool,
+
+        /** Optional icon to display along with or instead of text. */
         icon: PT.element,
+
+        /** True (default) to show a "flat" button with icon/text only - no 3D gradient. */
         minimal: PT.bool,
+
+        /** Callback when clicked, passed click event. */
         onClick: PT.func,
+
+        /** Style props - will be merged with any styles specified via layoutSupport props. */
         style: PT.object,
+
+        /** Primary label - provide this and/or icon. */
         text: PT.string,
-        title: PT.string,
-        autoFocus: PT.bool
+
+        /** Text for title attribute to provide basic tooltip support. */
+        title: PT.string
     };
 
     baseClassName = 'xh-button';

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -10,6 +10,9 @@ import PT from 'prop-types';
 import {elemFactory, HoistComponent, LayoutSupport} from '@xh/hoist/core';
 import {button as bpButton} from '@xh/hoist/kit/blueprint';
 
+import './Button.scss';
+
+
 /**
  * Wrapper around Blueprint's Button component. Defaults to the `minimal` style for reduced chrome
  * and adds LayoutSupport for top-level sizing and margin/padding props.
@@ -26,18 +29,21 @@ export class Button extends Component {
         onClick: PT.func,
         style: PT.object,
         text: PT.string,
-        title: PT.string
+        title: PT.string,
+        autoFocus: PT.bool
     };
 
     baseClassName = 'xh-button';
 
     render() {
-        const {icon, text, onClick, minimal = true, style, ...rest} = this.getNonLayoutProps();
+        const {icon, text, onClick, minimal = true, style, autoFocus, ...rest} = this.getNonLayoutProps(),
+            autoFocusClassName = autoFocus ? ' xh-button--autofocus-enabled' : '';
         return bpButton({
             icon,
             minimal,
             onClick,
             text,
+            autoFocus,
 
             style: {
                 ...style,
@@ -45,7 +51,7 @@ export class Button extends Component {
             },
 
             ...rest,
-            className: this.getClassName(minimal ? 'xh-button--minimal' : '')
+            className: this.getClassName(minimal ? `xh-button--minimal${autoFocusClassName}` : autoFocusClassName)
         });
     }
 

--- a/desktop/cmp/button/Button.js
+++ b/desktop/cmp/button/Button.js
@@ -37,7 +37,11 @@ export class Button extends Component {
 
     render() {
         const {icon, text, onClick, minimal = true, style, autoFocus, ...rest} = this.getNonLayoutProps(),
-            autoFocusClassName = autoFocus ? ' xh-button--autofocus-enabled' : '';
+            classes = [];
+
+        if (minimal) classes.push('xh-button--minimal');
+        if (autoFocus) classes.push('xh-button--autofocus-enabled');
+
         return bpButton({
             icon,
             minimal,
@@ -51,7 +55,7 @@ export class Button extends Component {
             },
 
             ...rest,
-            className: this.getClassName(minimal ? `xh-button--minimal${autoFocusClassName}` : autoFocusClassName)
+            className: this.getClassName(classes)
         });
     }
 

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -1,0 +1,9 @@
+.xh-button--autofocus-enabled {
+    &:focus {
+        // when autofocus is true on a button, 
+        // this will override BP's disabling of focus outline
+        // that occurs when BP's FocusStyleManager.onlyShowFocusOnTabs is active.
+        outline: var(--xh-focus-outline) !important;
+        outline-offset: var(--xh-focus-outline-offset-px) !important;
+    }
+}

--- a/desktop/cmp/button/Button.scss
+++ b/desktop/cmp/button/Button.scss
@@ -1,8 +1,8 @@
 .xh-button--autofocus-enabled {
+    // Hoist calls FocusStyleManager.onlyShowFocusOnTabs(), which by default hides focus indicators
+    // unless a component has been tabbed into via keyboard. Override here to always show a focus
+    // indicator for an autoFocus button so it's clear that it has focus.
     &:focus {
-        // when autofocus is true on a button, 
-        // this will override BP's disabling of focus outline
-        // that occurs when BP's FocusStyleManager.onlyShowFocusOnTabs is active.
         outline: var(--xh-focus-outline) !important;
         outline-offset: var(--xh-focus-outline-offset-px) !important;
     }

--- a/kit/blueprint/index.js
+++ b/kit/blueprint/index.js
@@ -10,6 +10,8 @@ import '@blueprintjs/datetime/lib/css/blueprint-datetime.css';
 import {Dialog, FocusStyleManager, Overlay, Popover} from '@blueprintjs/core';
 import './styles.scss';
 
+// Only show focus indicators when tabbing through components - avoids drawing focus outlines
+// on focusable components when focused via mouse click.
 FocusStyleManager.onlyShowFocusOnTabs();
 
 // Disable fade/scale-in transitions.

--- a/mobile/appcontainer/Message.js
+++ b/mobile/appcontainer/Message.js
@@ -30,25 +30,21 @@ class Message extends Component {
     render() {
         const model = this.model,
             isOpen = model && model.isOpen,
-            {icon, title, message, formModel, cancelText, confirmText} = model,
+            {icon, title, message, formModel, cancelProps, confirmProps} = model,
             buttons = [];
 
         if (!isOpen) return null;
 
-        if (cancelText) {
-            buttons.push(button({
-                text: cancelText,
-                modifier: 'quiet',
-                onClick: this.onCancel
-            }));
+        if (cancelProps) {
+            buttons.push(button({modifier: 'quiet', ...cancelProps}));
         }
 
-        if (confirmText) {
-            buttons.push(button({
-                text: confirmText,
-                disabled: formModel ? !formModel.isValid : false,
-                onClick: () => this.model.doConfirmAsync()
-            }));
+        if (confirmProps) {
+            // Merge in formModel.isValid here in render stage to get reactivity.
+            buttons.push(formModel ?
+                button({...confirmProps, disabled: !formModel.isValid}) :
+                button(confirmProps)
+            );
         }
 
         if (buttons.length) {

--- a/styles/vars.scss
+++ b/styles/vars.scss
@@ -56,8 +56,8 @@ body {
 
   // Focus indicator outline for interactive components - apps can use `--focus-outline: 0;` if
   // they wish to disable completely. Note form inputs provide their own dedicated props.
-  --xh-focus-outline-width-px: var(--focus-outline-width-px, 2px);
-  --xh-focus-outline-offset-px: var(--focus-outline-offset-px, 2px);
+  --xh-focus-outline-width-px: var(--focus-outline-width-px, .5px);
+  --xh-focus-outline-offset-px: var(--focus-outline-offset-px, -1px);
   --xh-focus-outline-color: var(--focus-outline-color, rgba(19, 124, 189, 0.6));
   --xh-focus-outline: var(--focus-outline, #{(var(--xh-focus-outline-width-px) auto var(--xh-focus-outline-color))});
 


### PR DESCRIPTION
Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [N/A] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [x] Reviewed and tested on Mobile
- [x] Created Toolbox branch / PR [https://github.com/exhi/toolbox/pull/238]((https://github.com/exhi/toolbox/pull/238))

This is a non-breaking change that some users would like in a hurry.  Would be good if it could be added to framework in feature release 25.3

This change allows autofocus on any button.
In message, alert, and prompt dialogs, autofocus can put on the input, cancel, or confirm components.

This change also affects the outline that appears on non-input focused components - ie: buttons.  The outline is thinner and not offset as much.