### PR TITLE
Grid summary/pinned data fixes (Fixes #1289, #1290)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,3 +9,5 @@ Review and check off the below. Items that do not apply should be checked to ind
 - [ ] Updated doc comments / prop-types (or N/A)
 - [ ] Reviewed and tested on Mobile (or N/A)
 - [ ] Created Toolbox branch / PR (link provided here, or N/A)
+
+> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to collapse multiple intermediate commits into a single commit representing the overall feature change. This helps keep the commit log clean and easy to scan across releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@
 
 * `GridModel` now supports a `copyCell` context menu action. See `StoreContextMenu` for more details.
 
-
 ### 💥 Breaking Changes
 
 * `StoreCountLabel` has been moved from `/desktop/cmp/store` to the cross-platform package
@@ -29,9 +28,17 @@
   to the new `GridCountLabel` component, noted above and imported from `/cmp/grid`.
 
 * The API for `ClipboardButton` and `ClipboardMenuItem` has been simplified, and made implementation
-independent.  Specify a single `getCopyText` function rather than the `clipboardSpec`.  (`clipboardSpec`
-is an artifact from the removed `clipboard` library).
+  independent.  Specify a single `getCopyText` function rather than the `clipboardSpec`.  (`clipboardSpec`
+  is an artifact from the removed `clipboard` library).
 
+### 🐞 Bug Fixes
+
+* Applications can again use the ag-Grid pinned data apis without having their data overwritten when
+  the Grid data or summary data changes
+  
+* Store will no longer trigger reactions on its observable properties when `updateData` is called 
+  with an empty `rawData` parameter (allows updating of summary data from a reaction on `records`
+  without causing mobx errors)
 
 ### ⚙️ Technical
 

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -387,6 +387,22 @@ export class AgGridModel {
         return id;
     }
 
+    /**
+     * @returns {Array} - row data pinned to the top of the grid
+     */
+    getPinnedTopRowData() {
+        this.throwIfNotReady();
+        return this.getPinnedRowData('Top');
+    }
+
+    /**
+     * @returns {Array} - row data pinned to the bottom of the grid
+     */
+    getPinnedBottomRowData() {
+        this.throwIfNotReady();
+        return this.getPinnedRowData('Bottom');
+    }
+
     //------------------------
     // Implementation
     //------------------------
@@ -402,6 +418,19 @@ export class AgGridModel {
         console.debug('AgGridModel Uninitializing!');
         this.agApi = null;
         this.agColumnApi = null;
+    }
+
+    getPinnedRowData(side) {
+        const {agApi} = this,
+            count = agApi[`getPinned${side}RowCount`](),
+            ret = [];
+
+        for (let i = 0; i < count; ++i) {
+            ret.push(agApi[`getPinned${side}Row`](i).data);
+        }
+
+        return ret;
+
     }
 
     getPivotColumnId(column) {

--- a/cmp/ag-grid/AgGridModel.js
+++ b/cmp/ag-grid/AgGridModel.js
@@ -388,11 +388,29 @@ export class AgGridModel {
     }
 
     /**
+     * Sets the data used for rows which appear pinned to the top of the grid
+     * @param {Object[]} data - the data to pin at the top of the grid
+     */
+    setPinnedTopRowData(data) {
+        this.throwIfNotReady();
+        this.agApi.setPinnedTopRowData(data);
+    }
+
+    /**
      * @returns {Array} - row data pinned to the top of the grid
      */
     getPinnedTopRowData() {
         this.throwIfNotReady();
         return this.getPinnedRowData('Top');
+    }
+
+    /**
+     * Sets the data used for rows which appear pinned to the bottom of the grid
+     * @param {Object[]} data - the data to pin at the bottom of the grid
+     */
+    setPinnedBottomRowData(data) {
+        this.throwIfNotReady();
+        this.agApi.setPinnedBottomRowData(data);
     }
 
     /**

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -543,7 +543,7 @@ export class Grid extends Component {
             if (showSummary === 'bottom') {
                 pinnedBottomRowData.push(store.summaryRecord);
             } else {
-                pinnedTopRowData.splice(0, 0, store.summaryRecord);
+                pinnedTopRowData.unshift(store.summaryRecord);
             }
         }
 

--- a/cmp/grid/Grid.js
+++ b/cmp/grid/Grid.js
@@ -140,7 +140,6 @@ export class Grid extends Component {
         this.addReaction(this.columnStateReaction());
         this.addReaction(this.dataReaction());
         this.addReaction(this.groupReaction());
-        this.addReaction(this.summaryReaction());
 
         this.agOptions = merge(this.createDefaultAgOptions(), props.agOptions || {});
     }
@@ -342,25 +341,12 @@ export class Grid extends Component {
     //------------------------
     // Reactions to model
     //------------------------
-    summaryReaction() {
-        const {model} = this,
-            {agGridModel, store} = model;
-
-        return {
-            track: () => [agGridModel.agApi, store.summaryRecord, model.showSummary],
-            run: ([api]) => {
-                if (!api) return;
-                this.updatePinnedSummaryRowData();
-            }
-        };
-    }
-
     dataReaction() {
         const {model} = this,
             {agGridModel, store} = model;
 
         return {
-            track: () => [agGridModel.agApi, store.records, store.lastUpdated],
+            track: () => [agGridModel.agApi, store.records, store.lastUpdated, store.summaryRecord, model.showSummary],
             run: ([api, records]) => {
                 if (!api) return;
 
@@ -372,6 +358,7 @@ export class Grid extends Component {
 
                         // Load updated data into the grid.
                         api.setRowData(records);
+                        this.updatePinnedSummaryRowData();
 
                         // Size columns to account for scrollbar show/hide due to row count change.
                         api.sizeColumnsToFit();

--- a/data/Record.js
+++ b/data/Record.js
@@ -58,10 +58,6 @@ export class Record {
         return this.store.getChildrenById(this.id, false);
     }
 
-    get isSummary() {
-        return this === this.store.summaryRecord;
-    }
-
     /**
      * Construct a Record from a raw source object. Extract values from the source object for all
      * Fields defined on the given Store and install them as top-level properties on the new Record.

--- a/data/Store.js
+++ b/data/Store.js
@@ -129,21 +129,27 @@ export class Store {
             'Cannot provide rawSummaryData to updateData when loadRootAsSummary is true.'
         );
 
-        const oldSummary = this.summaryRecord,
-            newSummary = this.getRootSummary(rawData);
-        if (oldSummary && newSummary && oldSummary.id === this.buildRecordId(newSummary)) {
-            rawData = newSummary.children;
-            rawSummaryData = {...newSummary, children: null};
-        }
+        let didUpdate = false;
+        if (!isEmpty(rawData)) {
+            const oldSummary = this.summaryRecord,
+                newSummary = this.getRootSummary(rawData);
+            if (oldSummary && newSummary && oldSummary.id === this.buildRecordId(newSummary)) {
+                rawData = newSummary.children;
+                rawSummaryData = {...newSummary, children: null};
+            }
 
-        this._all = this._all.updateData(rawData);
-        this.rebuildFiltered();
+            this._all = this._all.updateData(rawData);
+            this.rebuildFiltered();
+
+            didUpdate = true;
+        }
 
         if (rawSummaryData) {
             this.summaryRecord = this.createRecord(rawSummaryData);
+            didUpdate = true;
         }
 
-        this.lastUpdated = Date.now();
+        if (didUpdate) this.lastUpdated = Date.now();
     }
 
     /**
@@ -253,7 +259,6 @@ export class Store {
     /** @returns {StoreFilter} - the current filter (if any) applied to the store. */
     get filter() {return this._filter}
 
-
     /** Get the count of all records loaded into the store. */
     get allCount() {
         return this._all.count;
@@ -339,7 +344,6 @@ export class Store {
         return isString(idSpec) ? data[idSpec] : idSpec(data);
     }
 
-
     /** Destroy this store, cleaning up any resources used. */
     destroy() {}
 
@@ -374,7 +378,9 @@ export class Store {
     }
 
     getRootSummary(rawData) {
-        return this._loadRootAsSummary && rawData.length === 1 && !isEmpty(rawData[0].children) ? rawData[0] : null;
+        return this._loadRootAsSummary && rawData.length === 1 && !isEmpty(rawData[0].children) ?
+            rawData[0] :
+            null;
     }
 }
 

--- a/data/Store.js
+++ b/data/Store.js
@@ -105,7 +105,7 @@ export class Store {
         this._all = this._all.loadData(rawData);
         this.rebuildFiltered();
 
-        this.summaryRecord = rawSummaryData ? this.createRecord(rawSummaryData) : null;
+        this.summaryRecord = rawSummaryData ? this.createSummaryRecord(rawSummaryData) : null;
 
         this.lastUpdated = Date.now();
     }
@@ -129,7 +129,6 @@ export class Store {
             'Cannot provide rawSummaryData to updateData when loadRootAsSummary is true.'
         );
 
-        let didUpdate = false;
         if (!isEmpty(rawData)) {
             const oldSummary = this.summaryRecord,
                 newSummary = this.getRootSummary(rawData);
@@ -140,16 +139,12 @@ export class Store {
 
             this._all = this._all.updateData(rawData);
             this.rebuildFiltered();
-
-            didUpdate = true;
+            this.lastUpdated = Date.now();
         }
 
         if (rawSummaryData) {
-            this.summaryRecord = this.createRecord(rawSummaryData);
-            didUpdate = true;
+            this.summaryRecord = this.createSummaryRecord(rawSummaryData);
         }
-
-        if (didUpdate) this.lastUpdated = Date.now();
     }
 
     /**
@@ -381,6 +376,12 @@ export class Store {
         return this._loadRootAsSummary && rawData.length === 1 && !isEmpty(rawData[0].children) ?
             rawData[0] :
             null;
+    }
+
+    createSummaryRecord(rawData) {
+        const rec = this.createRecord(rawData);
+        rec.xhIsSummary = true;
+        return rec;
     }
 }
 

--- a/data/Store.js
+++ b/data/Store.js
@@ -129,6 +129,7 @@ export class Store {
             'Cannot provide rawSummaryData to updateData when loadRootAsSummary is true.'
         );
 
+        let didUpdate = false;
         if (!isEmpty(rawData)) {
             const oldSummary = this.summaryRecord,
                 newSummary = this.getRootSummary(rawData);
@@ -139,12 +140,15 @@ export class Store {
 
             this._all = this._all.updateData(rawData);
             this.rebuildFiltered();
-            this.lastUpdated = Date.now();
+            didUpdate = true;
         }
 
         if (rawSummaryData) {
             this.summaryRecord = this.createSummaryRecord(rawSummaryData);
+            didUpdate = true;
         }
+
+        if (didUpdate) this.lastUpdated = Date.now();
     }
 
     /**


### PR DESCRIPTION
Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or add `wip` label).
- [x] Added CHANGELOG entry (or N/A)
- [x] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [N/A] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to collapse multiple intermediate commits into a single commit representing the overall feature change. This helps keep the commit log clean and easy to scan across releases.

Restores support for application usage of the ag-Grid pinned data apis and fixes potential issuers where an application might want to update summary data from a reaction on the Store `records` property.

We now flag the summary record with `xhIsSummary=true` so the Grid can identify it when updating the pinned row data if the summary row is enabled. Grid will extract it from the existing pinned row data and place it back in the appropriate place (top-most for top pinned, bottom-most for bottom pinned). I also moved updating of the pinned data to its own reaction instead of using the data reaction as it was unnecessary to do all the extra work that is done in data reaction and ti seemed like a valid/common use-case where applications would want to update the summary data whenever the Store filter is applied to the `records`, which could/would result in an extra data reaction after the summary data was updated.

In `Store.updateData()` we also now avoid updating our RecordSet references and `lastUpdated` property unless the supplied `rawData` is not empty. This will allow applications to update the summary data with a call like `store.updateData([], newSummaryData)` without causing an infinite loop of reactions.
