### PR TITLE
Fix Onsen navigator issues.

### DIFF
--- a/mobile/cmp/navigator/NavigatorModel.js
+++ b/mobile/cmp/navigator/NavigatorModel.js
@@ -118,22 +118,51 @@ export class NavigatorModel {
     }
 
     onPagesChange() {
+        this.updateNavigatorPagesAsync().then(() => {
+            this.updatePageVisibility();
+        });
+    }
+
+    async updateNavigatorPagesAsync() {
+        if (!this._navigator) return;
         const {pages} = this,
             keyStack = pages.map(it => it.key),
-            prevKeyStack = this._prevKeyStack || [];
-
-        // If we have gone back one page in the same stack, we can safely pop() the page
-        if (isEqual(keyStack, prevKeyStack.slice(0, -1))) {
-            this._navigator.popPage();
-        } else {
-            this._navigator.resetPageStack(pages);
-        }
+            prevKeyStack = this._prevKeyStack || [],
+            backOnePage = isEqual(keyStack, prevKeyStack.slice(0, -1)),
+            forwardOnePage = isEqual(keyStack.slice(0, -1), prevKeyStack);
 
         this._prevKeyStack = keyStack;
+
+        if (backOnePage) {
+            // If we have gone back one page in the same stack, we can safely pop() the page
+            return this._navigator.popPage();
+        } else if (forwardOnePage) {
+            // If we have gone forward one page in the same stack, we can safely push() the new page
+            return this._navigator.pushPage(pages[pages.length - 1]);
+        } else {
+            // Otherwise, we should reset the page stack
+            return this._navigator.resetPageStack(pages);
+        }
+    }
+
+    // Ensure only the last page is visible after a page transition.
+    // Onsen performs similar logic itself during each page transition - however, an issue
+    // with transient duplicate pages can sometimes mess this up and leave you with hidden pages.
+    // We re-run this operation ourselves here to make sure the correct page is shown.
+    //
+    // See https://github.com/OnsenUI/OnsenUI/issues/2682
+    updatePageVisibility() {
+        if (!this._navigator) return;
+        const {pages} = this._navigator._navi;
+        pages.forEach((pageEl, idx) => {
+            const lastPage = idx === pages.length - 1;
+            pageEl.style.display = lastPage ? 'block' : 'none';
+        });
     }
 
     renderPage(pageModel, navigator) {
-        const {init, key, content, props} = pageModel;
+        const {init, content, props} = pageModel;
+        let key = pageModel.key;
 
         // Note: We use the special "init" object to obtain a reference to the
         // navigator and to read the initial route.
@@ -144,6 +173,28 @@ export class NavigatorModel {
             }
             return null;
         }
+
+        // This is a workaround for an Onsen issue with resetPageStack(),
+        // which can result in transient duplicate pages in a stack. Having duplicate pages
+        // will cause React to throw with a duplicate key error. The error occurs
+        // when navigating from one page stack to another where the last page of
+        // the new stack is already present in the previous stack.
+        //
+        // For this workaround, we identify the duplicate page (the one at the incorrect index)
+        // and suffix its key to ensure it is unique during its transient render. This page is
+        // then dropped in the next render of the Onsen navigator.
+        //
+        // See https://github.com/OnsenUI/OnsenUI/issues/2682
+        const onsenNavPages = this._navigator.routes.filter(it => !it.init),
+            hasDupes = onsenNavPages.filter(it => it.key === key).length > 1;
+
+        if (hasDupes) {
+            const onsenIdx = onsenNavPages.indexOf(pageModel),
+                ourIdx = this.pages.findIndex(it => it.key === key);
+
+            if (onsenIdx !== ourIdx) key += `&onsenIdx=${onsenIdx}`;
+        }
+
         return content.prototype.render ? elem(content, {key, ...props}) : content({key, ...props});
     }
 


### PR DESCRIPTION
Workaround for Onsen issue with duplicate pages while resetting the page stack.

Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [X] Up to date with `develop` branch as of last change.
- [X] Ready for review (or add `wip` label).
- [X] Added CHANGELOG entry (or N/A)
- [X] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [X] Updated doc comments / prop-types (or N/A)
- [X] Reviewed and tested on Mobile (or N/A)
- [X] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to collapse multiple intermediate commits into a single commit representing the overall feature change. This helps keep the commit log clean and easy to scan across releases.
