### PR TITLE
Make Buttons in ButtonGroupInput individually disable-able, Fixes #1348

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   supported (by both Hoist and React) using the familiar `@HoistComponent` decorator.
 * The default text input shown by `XH.prompt()` now has `selectOnFocus: true` and will confirm the
   user's entry on an <enter> keypress (same as clicking 'OK').
+* Individual `Buttons` within a `ButtonGroupInput` will accept a disabled prop while continuing 
+  to respect the overall `ButtonGroupInput`'s disabled prop.
 
 ### 💥 Breaking Changes
 

--- a/desktop/cmp/input/ButtonGroupInput.js
+++ b/desktop/cmp/input/ButtonGroupInput.js
@@ -40,7 +40,8 @@ export class ButtonGroupInput extends HoistInput {
         const buttons = castArray(children).map(button => {
             if (!button) return null;
 
-            const {value} = button.props;
+            const {value} = button.props,
+                btnDisabled = disabled || button.props.disabled;
 
             throwIf(button.type !== Button, 'ButtonGroupInput child must be a Button.');
             throwIf(value == null, 'ButtonGroupInput child must declare a non-null value');
@@ -49,7 +50,7 @@ export class ButtonGroupInput extends HoistInput {
             return React.cloneElement(button, {
                 active,
                 minimal: withDefault(minimal, false),
-                disabled: withDefault(disabled, false),
+                disabled: withDefault(btnDisabled, false),
                 onClick: () => {
                     if (enableClear) {
                         this.noteValueChange(active ? null : value);


### PR DESCRIPTION
Hoist P/R Checklist
-------------------
Review and check off the below. Items that do not apply should be checked to indicate they have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [X] Up to date with `develop` branch as of last change.
- [X] Ready for review (or add `wip` label).
- [X] Added CHANGELOG entry (or N/A)
- [X] Checked for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [X] Updated doc comments / prop-types (or N/A)
- [X] Reviewed and tested on Mobile (or N/A)
- [X] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to collapse multiple intermediate commits into a single commit representing the overall feature change. This helps keep the commit log clean and easy to scan across releases.
