### PR TITLE
Smaller cleanups to TrackService

### DIFF
--- a/admin/AppModel.js
+++ b/admin/AppModel.js
@@ -23,7 +23,7 @@ export class AppModel {
         switcherPosition: 'none',
         tabs: this.createTabs()
     });
-    
+
     getRoutes() {
         return [
             {
@@ -90,7 +90,7 @@ export class AppModel {
     createTabs() {
         return [
             {id: 'general', icon: Icon.info(), content: GeneralTab},
-            {id: 'activity', icon: Icon.chartBar(), content: ActivityTab},
+            {id: 'activity', icon: Icon.analytics(), content: ActivityTab},
             {id: 'logging', icon: Icon.fileText(), content: LoggingTab},
             {id: 'monitor', icon: Icon.shieldCheck(), content: MonitorTab},
             {id: 'preferences', icon: Icon.bookmark(), content: PreferencesTab}

--- a/admin/tabs/activity/ActivityTab.js
+++ b/admin/tabs/activity/ActivityTab.js
@@ -4,12 +4,12 @@
  *
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
-import {hoistComponent} from '@xh/hoist/core';
 import {tabContainer} from '@xh/hoist/cmp/tab';
-
-import {TrackingPanel} from './tracking/TrackingPanel';
+import {hoistComponent} from '@xh/hoist/core';
+import {Icon} from '@xh/hoist/icon';
 import {ClientErrorPanel} from './clienterrors/ClientErrorPanel';
 import {FeedbackPanel} from './feedback/FeedbackPanel';
+import {TrackingPanel} from './tracking/TrackingPanel';
 
 export const ActivityTab = hoistComponent(
     () => tabContainer({
@@ -17,9 +17,9 @@ export const ActivityTab = hoistComponent(
             route: 'default.activity',
             switcherPosition: 'left',
             tabs: [
-                {id: 'tracking', content: TrackingPanel},
-                {id: 'clientErrors', content: ClientErrorPanel},
-                {id: 'feedback', content: FeedbackPanel}
+                {id: 'tracking', icon: Icon.analytics(), content: TrackingPanel},
+                {id: 'clientErrors', icon: Icon.warning(), content: ClientErrorPanel},
+                {id: 'feedback', icon: Icon.comment(), content: FeedbackPanel}
             ]
         }
     })

--- a/icon/Icon.js
+++ b/icon/Icon.js
@@ -15,6 +15,7 @@ import {toLower} from 'lodash';
 import {
     faAddressCard,
     faAlignJustify,
+    faAnalytics,
     faAngleDoubleDown,
     faAngleDoubleLeft,
     faAngleDoubleRight,
@@ -172,6 +173,7 @@ import {
 import {
     faAddressCard as faAddressCardLight,
     faAlignJustify as faAlignJustifyLight,
+    faAnalytics as faAnalyticsLight,
     faAngleDoubleDown as faAngleDoubleDownLight,
     faAngleDoubleLeft as faAngleDoubleLeftLight,
     faAngleDoubleRight as faAngleDoubleRightLight,
@@ -329,6 +331,7 @@ import {
 import {
     faAddressCard as faAddressCardSolid,
     faAlignJustify as faAlignJustifySolid,
+    faAnalytics as faAnalyticsSolid,
     faAngleDoubleDown as faAngleDoubleDownSolid,
     faAngleDoubleLeft as faAngleDoubleLeftSolid,
     faAngleDoubleRight as faAngleDoubleRightSolid,
@@ -488,6 +491,7 @@ library.add(
     faAddressCard, faAddressCardLight, faAddressCardSolid,
     faAddressCard, faAddressCardLight, faAddressCardSolid,
     faAlignJustify, faAlignJustifyLight, faAlignJustifySolid,
+    faAnalytics, faAnalyticsLight, faAnalyticsSolid,
     faAngleDoubleDown, faAngleDoubleDownLight, faAngleDoubleDownSolid,
     faAngleDoubleLeft, faAngleDoubleLeftLight, faAngleDoubleLeftSolid,
     faAngleDoubleRight, faAngleDoubleRightLight, faAngleDoubleRightSolid,
@@ -654,6 +658,7 @@ export const Icon = {
     accessDenied(p)     {return fa(p, 'ban')},
     add(p)              {return fa(p, 'plus-circle')},
     addressCard(p)      {return fa(p, 'address-card')},
+    analytics(p)        {return fa(p, 'analytics')},
     angleDoubleDown(p)  {return fa(p, 'angle-double-down')},
     angleDoubleLeft(p)  {return fa(p, 'angle-double-left')},
     angleDoubleRight(p) {return fa(p, 'angle-double-right')},

--- a/svc/TrackService.js
+++ b/svc/TrackService.js
@@ -5,7 +5,8 @@
  * Copyright © 2019 Extremely Heavy Industries Inc.
  */
 import {XH, HoistService} from '@xh/hoist/core';
-import {stripTags} from '@xh/hoist/utils/js';
+import {stripTags, withDefault} from '@xh/hoist/utils/js';
+import {isString} from 'lodash';
 
 @HoistService
 export class TrackService {
@@ -16,30 +17,34 @@ export class TrackService {
      * Client metadata is set automatically by the server's parsing of request headers.
      *
      * @param {(Object|string)} options - if a string, it will become the message value.
-     * @param {string} [options.msg] - Short description of the activity being tracked.
-     *      Required if options is an object.
-     *      Can be passed as `message` for backwards compatibility.
+     * @param {string} [options.message] - Short description of the activity being tracked.
+     *      Required if options is an object. Can be passed as `msg` for backwards compatibility.
      * @param {string} [options.category] - app-supplied category.
-     * @param {(Object|Object[])} [options.data] - app-supplied data collection.
+     * @param {(Object|Object[])} [options.data] - app-supplied data to save along with track log.
      * @param {number} [options.elapsed] - time in milliseconds the activity took.
-     * @param {string} [options.severity] - importance flag, such as: OK|WARN|EMERGENCY
-     *      (errors should be tracked by the ErrorTrackingService, not sent in this TrackService).
+     * @param {string} [options.severity] - flag to indicate relative importance of activity.
+     *      Default 'INFO'. Note, errors should be tracked via `XH.handleException()`, which
+     *      will post to the server for dedicated logging if requested. {@see ExceptionHandler}
      * @param {LoadSpec} [options.loadSpec] - optional LoadSpec associated with this track.
-     *      If load is an auto-refresh (loadSpec.autoRefresh = true), this tracking will be skipped.
+     *      If the loadSpec indicates this is an auto-refresh, tracking will be skipped.
      */
     track(options) {
-        if (options.loadSpec && options.loadSpec.isAutoRefresh) return;
+        // Normalize string form, msg -> message, default severity.
+        if (isString(options)) options = {message: options};
+        options.message = withDefault(options.message, options.msg);
+        options.severity = withDefault(options.severity, 'INFO');
 
-        let msg = options;
-        if (typeof msg !== 'string') {
-            msg = options.msg !== undefined ? options.msg : options.message;
+        if (!options.message) {
+            console.warn('Tracking requires a message - activity will not be tracked.');
+            return;
         }
-        
+
+        // Short-circuit tracks from auto-refreshes and unauthenticated users.
         const username = XH.getUsername();
-        if (!username) return;
+        if (!username || (options.loadSpec && options.loadSpec.isAutoRefresh)) return;
 
         const params = {
-            msg: stripTags(msg),
+            msg: stripTags(options.message),
             clientUsername: username
         };
 
@@ -50,7 +55,7 @@ export class TrackService {
             if (options.severity)               params.severity = options.severity;
 
             const consoleMsg =
-                [params.category, params.msg, params.elapsed]
+                ['[Track]', params.category, params.msg, params.elapsed]
                     .filter(it => it != null)
                     .join(' | ');
 


### PR DESCRIPTION
+ Standardize on `message` as documented config for main string message, still support msg as alias. Make no-op if message not provided.
+ Restore broken support for string form (`XH.track('Hello')`) shortcut, as documented.
+ Default severity to "INFO" vs. non-standard seeming "OK". Will update hoist-core default to match as well.
+ Prepend track console logs with [Track] to differentiate them, match other [XH] logs, etc.
+ Fixup incorrect doc comments on service
+ Tweaks to admin interface - column swap, icons

Hoist P/R Checklist
-------------------

Review and check off the below. Items that do not apply can also be checked off to indicate they
have been considered. If unclear if a step is relevant, please leave unchecked and note in comments.

- [x] Up to date with `develop` branch as of last change.
- [x] Ready for review (or open as a draft PR / add `wip` label).
- [N/A] Added CHANGELOG entry (or N/A)
- [N/A] Reviewed for breaking changes (add `breaking-change` label + CHANGELOG if so, or N/A)
- [x] Updated doc comments / prop-types (or N/A)
- [N/A] Reviewed and tested on Mobile (or N/A)
- [N/A] Created Toolbox branch / PR (link provided here, or N/A)

> **Pull request reviewers:** when merging this P/R, please consider using a *squash commit* to
> collapse multiple intermediate commits into a single commit representing the overall feature
> change. This helps keep the commit log clean and easy to scan across releases. PRs containing a
> single commit should be *rebased* when possible.

